### PR TITLE
ci(windows): sign exe and installer with Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,24 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Sign executable (Azure Trusted Signing)
+        # Sign the bare .exe *before* the MSI is built so the copy packed
+        # into the installer carries the signature too. AZURE_CLIENT_SECRET
+        # authenticates the App Registration; the remaining AZURE_* secrets
+        # select the Trusted Signing account / certificate profile.
+        uses: azure/artifact-signing-action@v2
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ github.workspace }}\target\release\OpenCADStudio.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Convert SVG icon to ICO
         shell: pwsh
         run: |
@@ -93,7 +111,10 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}" -replace '^v', ''
-          if (-not $version) { $version = "0.0.0" }
+          # workflow_dispatch runs use the branch name as ref_name, which
+          # is not a valid MSI ProductVersion — fall back to 0.0.0 so test
+          # builds still produce an installer.
+          if ($version -notmatch '^\d+(\.\d+){0,3}$') { $version = "0.0.0" }
           # WiX Toolset 3.x is pre-installed on windows-latest; $env:WIX
           # points to the install root. candle compiles .wxs → .wixobj
           # and light links it into the final .msi.
@@ -119,6 +140,22 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "candle failed" }
           & $light $wixObj -out $msiPath
           if ($LASTEXITCODE -ne 0) { throw "light failed" }
+
+      - name: Sign MSI installer (Azure Trusted Signing)
+        # The installer itself must be signed separately — light produces a
+        # fresh, unsigned .msi even though the .exe inside is already signed.
+        uses: azure/artifact-signing-action@v2
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ github.workspace }}\OpenCADStudio.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Upload artifacts to release
         if: github.event_name == 'release'


### PR DESCRIPTION
## What

Adds Authenticode code-signing to the Windows release artifacts via [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/):

- The bare `.exe` is signed **before** the MSI is built, so the copy packed into the installer carries the signature too.
- The `.msi` is signed after WiX `light` links it (the installer is a fresh, unsigned artifact even with a signed exe inside).
- Uses `azure/artifact-signing-action@v2` with SHA256 digests and Microsoft's RFC3161 timestamp server, so signatures remain valid after the short-lived signing certificate expires.

Credentials come from repository secrets, which are already configured on this repo: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME`, `AZURE_CERTIFICATE_PROFILE_NAME`. The certificate is Impertio Studio B.V.'s public-trust profile, which removes the SmartScreen 'unknown publisher' warning for users.

## Also fixed

The MSI version fallback: `workflow_dispatch` runs use the branch name as `ref_name`, which is not a valid numeric `ProductVersion`, so `candle` failed on any non-tag run. Non-numeric refs now fall back to `0.0.0`, which also lets you test this workflow with a manual dispatch instead of publishing a release.

## Tested

Verified end-to-end in my fork with a `workflow_dispatch` run: https://github.com/mojtabakarimi/OpenCADStudio/actions/runs/26947917022

`build-windows` passed with both signing steps, and `Get-AuthenticodeSignature` on the produced artifacts reports:

```
File      : OpenCADStudio.exe / OpenCADStudio.msi
Status    : Valid
Subject   : CN=Impertio Studio B.V., O=Impertio Studio B.V., ... C=NL
Issuer    : CN=Microsoft ID Verified CS AOC CA 04, O=Microsoft Corporation, C=US
Timestamp : CN=Microsoft Public RSA Time Stamping Authority, ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)