### PR TITLE
Add a Storm Sewer module: storm-drain network analysis (Rational + Manning + HGL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "rayon",
  "rfd",
  "rustc-hash 2.1.2",
+ "stormsewer",
  "truck-meshalgo",
  "truck-modeling",
  "truck-polymesh",
@@ -5175,6 +5176,10 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stormsewer"
+version = "0.1.0"
 
 [[package]]
 name = "strict-num"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.5.0"
 edition = "2021"
 build = "build.rs"
 
+[workspace]
+members = ["crates/stormsewer"]
+
 [dependencies]
 # vtkio (pulled in transitively via truck-meshalgo) depends on xz2 → lzma-sys,
 # which by default links the system liblzma dynamically. On macOS that bakes a
@@ -31,6 +34,9 @@ truck-shapeops = "0.4"
 # Fast non-cryptographic hasher. Handle/u64 keys dominate the hot block,
 # hatch, draw-depth and wire caches; the default SipHash is overkill there.
 rustc-hash = "2"
+# Storm-sewer hydrology/hydraulics engine (Rational + Manning + HGL). Local
+# crate; powers the `storm_sewer` ribbon module.
+stormsewer = { path = "crates/stormsewer" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/stormsewer/Cargo.toml
+++ b/crates/stormsewer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stormsewer"
+version = "0.1.0"
+edition = "2021"
+description = "Native-Rust storm sewer network hydrology & hydraulics (Rational method, Manning, HGL). Engine core for the Open CAD Studio storm-sewer module and HydroComplete."
+license = "GPL-3.0-or-later"
+repository = "https://github.com/mf4633/stormsewer"
+keywords = ["hydrology", "hydraulics", "stormwater", "civil-engineering", "cad"]
+categories = ["science", "simulation"]
+
+# Engine is std-only on purpose: dependency-light and WASM-friendly.
+[dependencies]
+
+[lib]
+name = "stormsewer"

--- a/crates/stormsewer/examples/sample.ssn
+++ b/crates/stormsewer/examples/sample.ssn
@@ -1,0 +1,18 @@
+# Sample storm-sewer network  (stormsewer-cli examples/sample.ssn)
+# A short, properly-sized trunk line: two catch basins + a junction to outfall.
+
+IDF        60 10 0.8       # i = 60 / (t+10)^0.8   (in/hr, t in minutes) ~ 5 in/hr
+TAILWATER  100.5           # outfall tailwater elevation (ft)
+MINTC      10              # minimum time of concentration (min)
+JUNCTIONK  0.5             # junction loss coefficient
+
+#    id    kind        x     y    invert  rim     area  C     tc_inlet
+NODE N1    inlet         0    0   104.0   110.0   1.0   0.70  12
+NODE N2    inlet       300    0   102.5   108.5   1.0   0.70  10
+NODE N3    junction    550    0   101.2   107.0   0.5   0.80  8
+NODE OUT   outfall     730    0   100.0   106.0
+
+#    id    from  to    length  dia   n      (dia: 15in=1.25, 18in=1.5, 21in=1.75)
+PIPE P1    N1    N2    300     1.25  0.013
+PIPE P2    N2    N3    250     1.50  0.013
+PIPE P3    N3    OUT   180     1.75  0.013

--- a/crates/stormsewer/src/bin/stormsewer-cli.rs
+++ b/crates/stormsewer/src/bin/stormsewer-cli.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! `stormsewer-cli` — run a storm-sewer analysis from a `.ssn` network file.
+//!
+//! Usage:  stormsewer-cli <network-file>
+//!
+//! See `stormsewer::parse` for the file format.
+
+use std::process::exit;
+use stormsewer::parse::parse_ssn;
+use stormsewer::report::format_analysis;
+
+fn die(msg: &str) -> ! {
+    eprintln!("error: {msg}");
+    exit(1);
+}
+
+fn main() {
+    let path = match std::env::args().nth(1) {
+        Some(p) => p,
+        None => die("usage: stormsewer-cli <network-file>"),
+    };
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| die(&format!("cannot read {path}: {e}")));
+    let parsed = parse_ssn(&text).unwrap_or_else(|e| die(&e));
+    match parsed.network.analyze(&parsed.idf, &parsed.options) {
+        Ok(a) => print!("{}", format_analysis(&a)),
+        Err(e) => die(&e.to_string()),
+    }
+}

--- a/crates/stormsewer/src/drawing.rs
+++ b/crates/stormsewer/src/drawing.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Convert an analyzed network into drawable primitives (CAD-agnostic).
+//!
+//! Produces a **plan** view (pipes as lines, structures as markers, flow/HGL
+//! labels) and a **profile** (HGL long-section of the main stem: ground,
+//! invert, and hydraulic-grade-line polylines). Coordinates are plain `f64`
+//! drawing units; the host CAD turns these into its own entities.
+
+use crate::network::{Analysis, Network, NodeKind};
+use std::collections::HashMap;
+
+/// A pipe drawn in plan.
+#[derive(Clone, Debug)]
+pub struct PlanPipe {
+    pub x1: f64,
+    pub y1: f64,
+    pub x2: f64,
+    pub y2: f64,
+    pub surcharged: bool,
+}
+
+/// A structure marker drawn in plan.
+#[derive(Clone, Debug)]
+pub struct PlanNode {
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+    pub kind: NodeKind,
+}
+
+/// A text label placed at a point.
+#[derive(Clone, Debug)]
+pub struct Label {
+    pub x: f64,
+    pub y: f64,
+    pub text: String,
+    pub height: f64,
+}
+
+/// Which line of the profile a polyline represents.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProfileRole {
+    Ground,
+    Invert,
+    Hgl,
+}
+
+/// A polyline (sequence of points) with a role.
+#[derive(Clone, Debug)]
+pub struct Polyline {
+    pub pts: Vec<(f64, f64)>,
+    pub role: ProfileRole,
+}
+
+/// The full set of primitives for a network drawing.
+#[derive(Clone, Debug, Default)]
+pub struct NetworkDrawing {
+    pub plan_pipes: Vec<PlanPipe>,
+    pub plan_nodes: Vec<PlanNode>,
+    pub plan_labels: Vec<Label>,
+    pub profile_lines: Vec<Polyline>,
+    pub profile_labels: Vec<Label>,
+}
+
+/// Layout / styling knobs for [`draw_network`].
+#[derive(Clone, Debug)]
+pub struct DrawConfig {
+    pub text_height: f64,
+    pub node_radius: f64,
+    /// Plan X mapped to profile X=0 (station origin in drawing units).
+    pub profile_origin_x: f64,
+    /// Drawing Y at which the profile datum elevation is plotted.
+    pub profile_origin_y: f64,
+    /// Horizontal scale: station feet → drawing units.
+    pub h_scale: f64,
+    /// Vertical exaggeration applied to elevations in the profile.
+    pub v_exag: f64,
+}
+
+impl Default for DrawConfig {
+    fn default() -> Self {
+        Self {
+            text_height: 5.0,
+            node_radius: 3.0,
+            profile_origin_x: 0.0,
+            profile_origin_y: -200.0,
+            h_scale: 1.0,
+            v_exag: 10.0,
+        }
+    }
+}
+
+/// Build plan + profile primitives for an analyzed network.
+pub fn draw_network(net: &Network, a: &Analysis, cfg: &DrawConfig) -> NetworkDrawing {
+    let mut d = NetworkDrawing::default();
+    let pos: HashMap<&str, (f64, f64)> =
+        net.nodes.iter().map(|n| (n.id.as_str(), (n.x, n.y))).collect();
+    let hgl: HashMap<&str, f64> = a.nodes.iter().map(|n| (n.id.as_str(), n.hgl)).collect();
+
+    // ── Plan: pipes + labels ────────────────────────────────────────────────
+    for pr in &a.pipes {
+        let (x1, y1) = pos[pr.from.as_str()];
+        let (x2, y2) = pos[pr.to.as_str()];
+        d.plan_pipes.push(PlanPipe { x1, y1, x2, y2, surcharged: pr.surcharged });
+        d.plan_labels.push(Label {
+            x: (x1 + x2) / 2.0,
+            y: (y1 + y2) / 2.0 + cfg.text_height,
+            text: format!("{}: {:.1} cfs {:.0}%", pr.id, pr.design_q, pr.pct_full * 100.0),
+            height: cfg.text_height,
+        });
+    }
+
+    // ── Plan: structure markers + labels ────────────────────────────────────
+    for n in &net.nodes {
+        d.plan_nodes.push(PlanNode { x: n.x, y: n.y, radius: cfg.node_radius, kind: n.kind });
+        let h = hgl.get(n.id.as_str()).copied().unwrap_or(f64::NAN);
+        let label = if h.is_finite() {
+            format!("{} HGL {:.1}", n.id, h)
+        } else {
+            n.id.clone()
+        };
+        d.plan_labels.push(Label {
+            x: n.x + cfg.node_radius,
+            y: n.y + cfg.node_radius,
+            text: label,
+            height: cfg.text_height,
+        });
+    }
+
+    // ── Profile of the main stem ────────────────────────────────────────────
+    let stem = main_stem(net);
+    if stem.len() >= 2 {
+        let nidx: HashMap<&str, usize> =
+            net.nodes.iter().enumerate().map(|(i, n)| (n.id.as_str(), i)).collect();
+
+        // Stations (ft) from the upstream end.
+        let mut stations = vec![0.0f64; stem.len()];
+        for k in 1..stem.len() {
+            let len = pipe_between(net, stem[k - 1], stem[k]).map(|p| p.length).unwrap_or(0.0);
+            stations[k] = stations[k - 1] + len;
+        }
+        let datum = stem.iter().map(|&i| net.nodes[i].invert).fold(f64::INFINITY, f64::min);
+        let px = |st: f64| cfg.profile_origin_x + st * cfg.h_scale;
+        let py = |elev: f64| cfg.profile_origin_y + (elev - datum) * cfg.v_exag;
+
+        let mut ground = Vec::new();
+        let mut invert = Vec::new();
+        let mut hgl_line = Vec::new();
+        for (k, &i) in stem.iter().enumerate() {
+            let n = &net.nodes[i];
+            let st = stations[k];
+            ground.push((px(st), py(n.rim)));
+            invert.push((px(st), py(n.invert)));
+            if let Some(&h) = hgl.get(n.id.as_str()) {
+                if h.is_finite() {
+                    hgl_line.push((px(st), py(h)));
+                }
+            }
+            d.profile_labels.push(Label {
+                x: px(st),
+                y: py(n.rim) + cfg.text_height,
+                text: n.id.clone(),
+                height: cfg.text_height,
+            });
+            let _ = nidx; // (reserved for future cross-refs)
+        }
+        d.profile_lines.push(Polyline { pts: ground, role: ProfileRole::Ground });
+        d.profile_lines.push(Polyline { pts: invert, role: ProfileRole::Invert });
+        if hgl_line.len() >= 2 {
+            d.profile_lines.push(Polyline { pts: hgl_line, role: ProfileRole::Hgl });
+        }
+    }
+
+    d
+}
+
+/// The main trunk, upstream-first: walk from the outfall up the incoming pipe
+/// whose upstream node carries the most accumulated drainage area.
+fn main_stem(net: &Network) -> Vec<usize> {
+    let n = net.nodes.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let nidx: HashMap<&str, usize> =
+        net.nodes.iter().enumerate().map(|(i, nd)| (nd.id.as_str(), i)).collect();
+    let mut incoming: Vec<Vec<usize>> = vec![Vec::new(); n]; // upstream node indices
+    let mut has_out = vec![false; n];
+    for p in &net.pipes {
+        if let (Some(&u), Some(&v)) = (nidx.get(p.from.as_str()), nidx.get(p.to.as_str())) {
+            incoming[v].push(u);
+            has_out[u] = true;
+        }
+    }
+    let ca = net.accumulate_ca().unwrap_or_default();
+    let size = |i: usize| ca.get(net.nodes[i].id.as_str()).copied().unwrap_or(0.0);
+
+    // Start at the outfall (kind, else the first node with no outgoing pipe).
+    let start = net
+        .nodes
+        .iter()
+        .position(|nd| nd.kind == NodeKind::Outfall)
+        .or_else(|| (0..n).find(|&i| !has_out[i]))
+        .unwrap_or(0);
+
+    let mut stem = vec![start];
+    let mut cur = start;
+    let mut guard = 0;
+    while guard < n {
+        guard += 1;
+        match incoming[cur].iter().copied().max_by(|&a, &b| {
+            size(a).partial_cmp(&size(b)).unwrap_or(std::cmp::Ordering::Equal)
+        }) {
+            Some(up) => {
+                stem.push(up);
+                cur = up;
+            }
+            None => break,
+        }
+    }
+    stem.reverse(); // upstream-first
+    stem
+}
+
+fn pipe_between<'a>(net: &'a Network, up: usize, dn: usize) -> Option<&'a crate::network::Pipe> {
+    let up_id = net.nodes[up].id.as_str();
+    let dn_id = net.nodes[dn].id.as_str();
+    net.pipes.iter().find(|p| p.from == up_id && p.to == dn_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idf::IdfCurve;
+    use crate::network::{AnalysisOptions, Node, Pipe};
+
+    fn sample() -> Network {
+        Network {
+            nodes: vec![
+                Node::inlet("N1", 104.0, 110.0, 1.0, 0.70).at(0.0, 0.0),
+                Node::inlet("N2", 102.5, 108.5, 1.0, 0.70).at(300.0, 0.0),
+                Node::junction("N3", 101.2, 107.0, 0.5, 0.80).at(550.0, 0.0),
+                Node::outfall("OUT", 100.0, 106.0).at(730.0, 0.0),
+            ],
+            pipes: vec![
+                Pipe::new("P1", "N1", "N2", 300.0, 1.25, 0.013),
+                Pipe::new("P2", "N2", "N3", 250.0, 1.50, 0.013),
+                Pipe::new("P3", "N3", "OUT", 180.0, 1.75, 0.013),
+            ],
+        }
+    }
+
+    fn analyzed() -> (Network, Analysis) {
+        let net = sample();
+        let a = net.analyze(&IdfCurve::new(60.0, 10.0, 0.8), &AnalysisOptions { tailwater: Some(100.5), ..Default::default() }).unwrap();
+        (net, a)
+    }
+
+    #[test]
+    fn plan_has_one_line_per_pipe_and_marker_per_node() {
+        let (net, a) = analyzed();
+        let d = draw_network(&net, &a, &DrawConfig::default());
+        assert_eq!(d.plan_pipes.len(), net.pipes.len());
+        assert_eq!(d.plan_nodes.len(), net.nodes.len());
+        assert!(d.plan_labels.len() >= net.pipes.len() + net.nodes.len());
+    }
+
+    #[test]
+    fn main_stem_is_full_trunk_upstream_first() {
+        let net = sample();
+        let stem = main_stem(&net);
+        let ids: Vec<&str> = stem.iter().map(|&i| net.nodes[i].id.as_str()).collect();
+        assert_eq!(ids, vec!["N1", "N2", "N3", "OUT"]);
+    }
+
+    #[test]
+    fn profile_has_ground_invert_and_hgl() {
+        let (net, a) = analyzed();
+        let d = draw_network(&net, &a, &DrawConfig::default());
+        let roles: Vec<ProfileRole> = d.profile_lines.iter().map(|p| p.role).collect();
+        assert!(roles.contains(&ProfileRole::Ground));
+        assert!(roles.contains(&ProfileRole::Invert));
+        assert!(roles.contains(&ProfileRole::Hgl));
+        for pl in &d.profile_lines {
+            assert!(pl.pts.len() >= 2, "{:?} too short", pl.role);
+        }
+    }
+}

--- a/crates/stormsewer/src/hydraulics.rs
+++ b/crates/stormsewer/src/hydraulics.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Open-channel & partial-flow hydraulics for circular closed conduits.
+//!
+//! US customary units throughout (feet, seconds, cfs). Pass `K_MANNING_SI`
+//! and `G_SI` for metric. All geometry is exact (no table lookups).
+
+use std::f64::consts::PI;
+
+/// Manning conversion factor, US customary (1.486 rounded to 1.49 by convention).
+pub const K_MANNING_US: f64 = 1.49;
+/// Manning conversion factor, SI.
+pub const K_MANNING_SI: f64 = 1.0;
+/// Gravitational acceleration, US customary (ft/s^2).
+pub const G_US: f64 = 32.2;
+/// Gravitational acceleration, SI (m/s^2).
+pub const G_SI: f64 = 9.81;
+
+/// Central angle (radians) subtended at the pipe centre by the water surface,
+/// for flow depth `y` in a circular pipe of diameter `d`.
+///
+/// `0` when empty, `2*PI` when full.
+pub fn circular_angle(y: f64, d: f64) -> f64 {
+    let y = y.clamp(0.0, d);
+    2.0 * (1.0 - 2.0 * y / d).acos()
+}
+
+/// Flow geometry at depth `y` in a circular pipe of diameter `d`.
+///
+/// Returns `(area, wetted_perimeter, hydraulic_radius, top_width)`.
+pub fn circular_geometry(y: f64, d: f64) -> (f64, f64, f64, f64) {
+    let theta = circular_angle(y, d);
+    let area = d * d / 8.0 * (theta - theta.sin());
+    let perim = d * theta / 2.0;
+    let radius = if perim > 0.0 { area / perim } else { 0.0 };
+    let top = d * (theta / 2.0).sin();
+    (area, perim, radius, top)
+}
+
+/// Full cross-sectional area of a circular pipe.
+pub fn full_area(d: f64) -> f64 {
+    PI * d * d / 4.0
+}
+
+/// Manning discharge from flow area and hydraulic radius.
+///
+/// `Q = (k/n) * A * R^(2/3) * S^(1/2)`
+pub fn manning_q(n: f64, s: f64, area: f64, radius: f64, k: f64) -> f64 {
+    if n <= 0.0 {
+        return 0.0;
+    }
+    k / n * area * radius.powf(2.0 / 3.0) * s.max(0.0).sqrt()
+}
+
+/// Just-full (geometrically full, free-surface) capacity of a circular pipe.
+///
+/// Note: the *maximum* open-channel discharge actually occurs near `0.94 d`
+/// and slightly exceeds this value — see [`max_capacity`].
+pub fn full_flow_capacity(n: f64, s: f64, d: f64, k: f64) -> f64 {
+    manning_q(n, s, full_area(d), d / 4.0, k)
+}
+
+/// Discharge at partial depth `y` in a circular pipe.
+pub fn circular_q(n: f64, s: f64, d: f64, y: f64, k: f64) -> f64 {
+    let (area, _p, radius, _t) = circular_geometry(y, d);
+    manning_q(n, s, area, radius, k)
+}
+
+/// Maximum open-channel discharge of a circular pipe and the depth at which it
+/// occurs (~`0.938 d`). Returns `(q_max, y_at_max)`.
+pub fn max_capacity(n: f64, s: f64, d: f64, k: f64) -> (f64, f64) {
+    // Q(y) is smooth with a single interior maximum; a fine scan is exact
+    // enough and cheap for the depths involved.
+    let steps = 2000;
+    let mut best_q = 0.0;
+    let mut best_y = 0.0;
+    for i in 1..=steps {
+        let y = d * i as f64 / steps as f64;
+        let q = circular_q(n, s, d, y, k);
+        if q > best_q {
+            best_q = q;
+            best_y = y;
+        }
+    }
+    (best_q, best_y)
+}
+
+/// Normal (uniform-flow) depth for a target discharge in a circular pipe.
+///
+/// Returns `None` when `q_target` exceeds the pipe's maximum open-channel
+/// capacity — i.e. the pipe must surcharge / flow under pressure.
+pub fn normal_depth(q_target: f64, n: f64, s: f64, d: f64, k: f64) -> Option<f64> {
+    if q_target <= 0.0 {
+        return Some(0.0);
+    }
+    let (q_max, y_max) = max_capacity(n, s, d, k);
+    if q_target > q_max {
+        return None;
+    }
+    // Q is monotonic increasing on (0, y_max]; bisect there.
+    let (mut lo, mut hi) = (0.0_f64, y_max);
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if circular_q(n, s, d, mid, k) > q_target {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+        if hi - lo < 1e-7 {
+            break;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+/// Critical depth for a target discharge in a circular pipe.
+///
+/// Solves `Q^2 * T = g * A^3` (Froude = 1). Valid for `0 < y < d`.
+pub fn critical_depth(q: f64, d: f64, g: f64) -> f64 {
+    if q <= 0.0 {
+        return 0.0;
+    }
+    let resid = |y: f64| {
+        let (area, _p, _r, top) = circular_geometry(y, d);
+        if area <= 0.0 || top <= 0.0 {
+            return -q * q;
+        }
+        q * q * top - g * area * area * area
+    };
+    // resid > 0 for small y, < 0 as y grows: bracket the sign change.
+    let (mut lo, mut hi) = (1e-6 * d, 0.999 * d);
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if resid(mid) > 0.0 {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if hi - lo < 1e-7 {
+            break;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const K: f64 = K_MANNING_US;
+
+    #[test]
+    fn full_area_matches_geometry() {
+        // Geometry at y = d must equal the closed-form full area.
+        let d = 2.0;
+        let (area, perim, r, _t) = circular_geometry(d, d);
+        assert!((area - full_area(d)).abs() < 1e-9);
+        assert!((perim - PI * d).abs() < 1e-9); // full wetted perimeter = pi*d
+        assert!((r - d / 4.0).abs() < 1e-9); // hydraulic radius full = d/4
+    }
+
+    #[test]
+    fn half_depth_is_half_area() {
+        // A circle is exactly half-full at half-diameter depth.
+        let d = 3.0;
+        let (area, _p, _r, _t) = circular_geometry(d / 2.0, d);
+        assert!((area - full_area(d) / 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn manning_capacity_known_value() {
+        // 2-ft pipe, n=0.013, s=0.005  ->  ~16.0 cfs full-flow (hand calc).
+        let q = full_flow_capacity(0.013, 0.005, 2.0, K);
+        assert!((q - 16.0).abs() < 0.2, "got {q}");
+    }
+
+    #[test]
+    fn normal_depth_round_trip() {
+        // Build a discharge from a depth, then recover the depth.
+        let (n, s, d) = (0.013, 0.01, 2.0);
+        let y0 = 1.2;
+        let q = circular_q(n, s, d, y0, K);
+        let y = normal_depth(q, n, s, d, K).expect("below capacity");
+        assert!((y - y0).abs() < 1e-3, "got {y}");
+    }
+
+    #[test]
+    fn surcharge_returns_none() {
+        // A tiny pipe cannot pass a huge flow as open channel.
+        let y = normal_depth(500.0, 0.013, 0.005, 1.0, K);
+        assert!(y.is_none());
+    }
+
+    #[test]
+    fn max_capacity_exceeds_full() {
+        // Peak open-channel flow occurs near 0.94 d and beats just-full.
+        let (qmax, ymax) = max_capacity(0.013, 0.005, 2.0, K);
+        let qfull = full_flow_capacity(0.013, 0.005, 2.0, K);
+        assert!(qmax > qfull);
+        assert!(ymax > 1.8 && ymax < 2.0, "y_at_max = {ymax}");
+    }
+
+    #[test]
+    fn critical_depth_in_range() {
+        let yc = critical_depth(10.0, 2.0, G_US);
+        assert!(yc > 0.0 && yc < 2.0, "yc = {yc}");
+    }
+}

--- a/crates/stormsewer/src/idf.rs
+++ b/crates/stormsewer/src/idf.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Rainfall intensity–duration–frequency (IDF) curves.
+//!
+//! Uses the common three-parameter form
+//!
+//! ```text
+//! i = a / (t + b)^c          (i in in/hr, t in minutes)
+//! ```
+//!
+//! which fits NOAA Atlas-14 partial-duration data well over the 5–180 min
+//! range used in storm-sewer design.
+
+/// A three-parameter IDF curve for a single return period.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IdfCurve {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+}
+
+impl IdfCurve {
+    pub fn new(a: f64, b: f64, c: f64) -> Self {
+        Self { a, b, c }
+    }
+
+    /// Rainfall intensity (in/hr) for a storm duration `t_min` (minutes).
+    pub fn intensity(&self, t_min: f64) -> f64 {
+        let t = t_min.max(0.0);
+        self.a / (t + self.b).powf(self.c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intensity_decreases_with_duration() {
+        let idf = IdfCurve::new(120.0, 10.0, 0.8);
+        let short = idf.intensity(5.0);
+        let long = idf.intensity(60.0);
+        assert!(short > long, "short {short} long {long}");
+        assert!(long > 0.0);
+    }
+
+    #[test]
+    fn intensity_known_value() {
+        // a=120,b=10,c=0.8 ; t=15 -> 120 / 25^0.8 = 9.14 in/hr (hand calc).
+        let idf = IdfCurve::new(120.0, 10.0, 0.8);
+        assert!((idf.intensity(15.0) - 9.14).abs() < 0.05, "{}", idf.intensity(15.0));
+    }
+}

--- a/crates/stormsewer/src/lib.rs
+++ b/crates/stormsewer/src/lib.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! # stormsewer
+//!
+//! Native-Rust storm-sewer network **hydrology & hydraulics** engine.
+//!
+//! It implements the standard, public-domain methods used by tools such as
+//! Autodesk Hydraflow Storm Sewers:
+//!
+//! * **Rational method** peak-flow accumulation down a pipe network,
+//! * **Manning** open-channel / partial-flow hydraulics for circular conduits,
+//! * normal-depth, critical-depth and full-flow capacity,
+//! * *(forthcoming)* **HEC-22** hydraulic-grade-line backwater with junction
+//!   and structure losses.
+//!
+//! This is an **engine only**: no GUI and no CAD dependencies, so it compiles
+//! to a native library, to WASM (for hydrocomplete.com), and is consumable as
+//! a module by an Open CAD Studio fork.
+//!
+//! ```
+//! use stormsewer::{Network, Node, NodeKind, Pipe};
+//! let net = Network {
+//!     nodes: vec![
+//!         Node::inlet("N1", 100.0, 105.0, 2.0, 0.7),
+//!         Node::outfall("OUT", 99.0, 104.0),
+//!     ],
+//!     pipes: vec![Pipe::new("P1", "N1", "OUT", 100.0, 1.5, 0.013)],
+//! };
+//! let results = net.analyze_rational(4.0).unwrap(); // i = 4 in/hr
+//! assert_eq!(results.len(), 1);
+//! assert!((results[0].design_q - 5.6).abs() < 1e-6); // 4 * (0.7*2.0)
+//! ```
+
+pub mod drawing;
+pub mod hydraulics;
+pub mod idf;
+pub mod network;
+pub mod parse;
+pub mod report;
+
+pub use drawing::*;
+pub use hydraulics::*;
+pub use idf::*;
+pub use network::*;
+pub use parse::*;

--- a/crates/stormsewer/src/network.rs
+++ b/crates/stormsewer/src/network.rs
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Storm-sewer network model: nodes (inlets / junctions / outfalls), pipes,
+//! topology, Rational-method peak-flow accumulation, time-of-concentration /
+//! IDF intensity, and a hydraulic-grade-line (HGL) backwater pass.
+//!
+//! The network is assumed **dendritic** (tree-like, draining to outfalls) as is
+//! standard for gravity storm sewers. Looped networks are rejected by the
+//! topological sort.
+
+use crate::hydraulics::*;
+use crate::idf::IdfCurve;
+use std::collections::HashMap;
+
+/// Kind of network node.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum NodeKind {
+    Inlet,
+    Junction,
+    Outfall,
+}
+
+/// A network node (structure).
+#[derive(Clone, Debug)]
+pub struct Node {
+    pub id: String,
+    pub kind: NodeKind,
+    /// Flowline / invert elevation (ft).
+    pub invert: f64,
+    /// Rim / ground elevation (ft) — used for surcharge-to-surface checks.
+    pub rim: f64,
+    /// Local contributing drainage area (acres).
+    pub area_ac: f64,
+    /// Rational runoff coefficient C for the local area (0–1).
+    pub c: f64,
+    /// Inlet time of concentration for the local catchment (minutes).
+    pub tc_inlet: f64,
+    /// Plan (map) X coordinate of the structure (drawing units).
+    pub x: f64,
+    /// Plan (map) Y coordinate of the structure (drawing units).
+    pub y: f64,
+}
+
+impl Node {
+    pub fn inlet(id: &str, invert: f64, rim: f64, area_ac: f64, c: f64) -> Self {
+        Self { id: id.into(), kind: NodeKind::Inlet, invert, rim, area_ac, c, tc_inlet: 10.0, x: 0.0, y: 0.0 }
+    }
+    pub fn junction(id: &str, invert: f64, rim: f64, area_ac: f64, c: f64) -> Self {
+        Self { id: id.into(), kind: NodeKind::Junction, invert, rim, area_ac, c, tc_inlet: 10.0, x: 0.0, y: 0.0 }
+    }
+    pub fn outfall(id: &str, invert: f64, rim: f64) -> Self {
+        Self { id: id.into(), kind: NodeKind::Outfall, invert, rim, area_ac: 0.0, c: 0.0, tc_inlet: 0.0, x: 0.0, y: 0.0 }
+    }
+    /// Builder: set the local inlet time (minutes).
+    pub fn with_tc_inlet(mut self, t_min: f64) -> Self {
+        self.tc_inlet = t_min;
+        self
+    }
+    /// Builder: set the plan (map) coordinates.
+    pub fn at(mut self, x: f64, y: f64) -> Self {
+        self.x = x;
+        self.y = y;
+        self
+    }
+    /// Local C*A product (acres).
+    pub fn ca(&self) -> f64 {
+        self.c * self.area_ac
+    }
+}
+
+/// A pipe (network link) carrying flow from `from` (upstream) to `to`.
+#[derive(Clone, Debug)]
+pub struct Pipe {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub length: f64,   // ft
+    pub diameter: f64, // ft
+    pub n: f64,        // Manning roughness
+}
+
+impl Pipe {
+    pub fn new(id: &str, from: &str, to: &str, length: f64, diameter: f64, n: f64) -> Self {
+        Self { id: id.into(), from: from.into(), to: to.into(), length, diameter, n }
+    }
+}
+
+/// A storm-sewer network.
+#[derive(Clone, Debug, Default)]
+pub struct Network {
+    pub nodes: Vec<Node>,
+    pub pipes: Vec<Pipe>,
+}
+
+/// Per-pipe analysis result.
+#[derive(Clone, Debug)]
+pub struct PipeResult {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    /// Pipe slope from upstream/downstream inverts (ft/ft).
+    pub slope: f64,
+    /// Accumulated C*A draining into this pipe (acres).
+    pub total_ca: f64,
+    /// Design rainfall intensity used (in/hr).
+    pub intensity: f64,
+    /// Time of concentration at the upstream end (minutes).
+    pub tc: f64,
+    /// Flow travel time through this pipe at design flow (minutes).
+    pub travel_time: f64,
+    /// Rational peak design discharge (cfs).
+    pub design_q: f64,
+    /// Just-full capacity (cfs).
+    pub capacity: f64,
+    /// Maximum open-channel capacity (~0.94 d) (cfs).
+    pub max_capacity: f64,
+    /// True if the design flow exceeds open-channel capacity (pipe surcharges).
+    pub surcharged: bool,
+    /// Normal depth (ft), or `None` if surcharged.
+    pub normal_depth: Option<f64>,
+    /// Critical depth (ft).
+    pub critical_depth: f64,
+    /// Actual velocity at design flow (ft/s).
+    pub velocity: f64,
+    /// Full-flow velocity (ft/s).
+    pub velocity_full: f64,
+    /// Design flow as a fraction of just-full capacity.
+    pub pct_full: f64,
+    /// HGL elevation at the upstream structure (ft), if an HGL pass was run.
+    pub hgl_up: Option<f64>,
+    /// HGL elevation at the downstream structure (ft), if an HGL pass was run.
+    pub hgl_dn: Option<f64>,
+}
+
+/// Per-node analysis result (populated by the HGL pass).
+#[derive(Clone, Debug)]
+pub struct NodeResult {
+    pub id: String,
+    pub tc: f64,
+    pub hgl: f64,
+    pub rim: f64,
+    /// True if the HGL rises above the rim (flooding).
+    pub surcharge_to_surface: bool,
+}
+
+/// Full network analysis (pipes + nodes).
+#[derive(Clone, Debug)]
+pub struct Analysis {
+    pub pipes: Vec<PipeResult>,
+    pub nodes: Vec<NodeResult>,
+}
+
+/// Options for [`Network::analyze`].
+#[derive(Clone, Debug)]
+pub struct AnalysisOptions {
+    /// Minimum time of concentration (minutes) — floors the IDF duration.
+    pub min_tc: f64,
+    /// Tailwater elevation at outfalls (ft). `None` → free outfall at invert.
+    pub tailwater: Option<f64>,
+    /// Junction/structure loss coefficient K in `H = K * V^2 / 2g`.
+    pub junction_k: f64,
+    /// If set, use this constant intensity (in/hr) instead of the IDF curve.
+    pub intensity_override: Option<f64>,
+}
+
+impl Default for AnalysisOptions {
+    fn default() -> Self {
+        Self { min_tc: 10.0, tailwater: None, junction_k: 0.5, intensity_override: None }
+    }
+}
+
+/// Errors raised during analysis.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NetworkError {
+    UnknownNode(String),
+    CyclicNetwork,
+}
+
+impl std::fmt::Display for NetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetworkError::UnknownNode(id) => write!(f, "pipe references unknown node '{id}'"),
+            NetworkError::CyclicNetwork => write!(f, "network contains a cycle"),
+        }
+    }
+}
+impl std::error::Error for NetworkError {}
+
+/// Conveyance K = (k/n) * A * R^(2/3), so that Q = K * sqrt(S).
+fn conveyance(n: f64, area: f64, radius: f64, k: f64) -> f64 {
+    if n <= 0.0 {
+        return 0.0;
+    }
+    k / n * area * radius.powf(2.0 / 3.0)
+}
+
+impl Network {
+    fn index(&self) -> HashMap<&str, usize> {
+        self.nodes.iter().enumerate().map(|(i, nd)| (nd.id.as_str(), i)).collect()
+    }
+
+    /// Topological node order, most-upstream first (Kahn's algorithm).
+    fn topo_order(&self, idx: &HashMap<&str, usize>) -> Result<Vec<usize>, NetworkError> {
+        let n = self.nodes.len();
+        let mut indeg = vec![0usize; n];
+        let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+        for p in &self.pipes {
+            let u = *idx.get(p.from.as_str()).ok_or_else(|| NetworkError::UnknownNode(p.from.clone()))?;
+            let v = *idx.get(p.to.as_str()).ok_or_else(|| NetworkError::UnknownNode(p.to.clone()))?;
+            adj[u].push(v);
+            indeg[v] += 1;
+        }
+        let mut queue: Vec<usize> = (0..n).filter(|&i| indeg[i] == 0).collect();
+        let mut order = Vec::with_capacity(n);
+        while let Some(u) = queue.pop() {
+            order.push(u);
+            for &v in &adj[u] {
+                indeg[v] -= 1;
+                if indeg[v] == 0 {
+                    queue.push(v);
+                }
+            }
+        }
+        if order.len() != n {
+            return Err(NetworkError::CyclicNetwork);
+        }
+        Ok(order)
+    }
+
+    /// Accumulated C*A (acres) reaching each node, keyed by node id.
+    pub fn accumulate_ca(&self) -> Result<HashMap<String, f64>, NetworkError> {
+        let idx = self.index();
+        let order = self.topo_order(&idx)?;
+        let mut feeders: Vec<Vec<usize>> = vec![Vec::new(); self.nodes.len()];
+        for p in &self.pipes {
+            feeders[idx[p.to.as_str()]].push(idx[p.from.as_str()]);
+        }
+        let mut total = vec![0.0f64; self.nodes.len()];
+        for &i in &order {
+            let mut acc = self.nodes[i].ca();
+            for &u in &feeders[i] {
+                acc += total[u];
+            }
+            total[i] = acc;
+        }
+        Ok(self.nodes.iter().enumerate().map(|(i, nd)| (nd.id.clone(), total[i])).collect())
+    }
+
+    /// Simple Rational analysis with one constant intensity (no Tc/HGL).
+    /// Retained for quick checks; [`analyze`](Self::analyze) is the full method.
+    pub fn analyze_rational(&self, intensity: f64) -> Result<Vec<PipeResult>, NetworkError> {
+        let opts = AnalysisOptions { intensity_override: Some(intensity), ..Default::default() };
+        // A flat IDF is unused when intensity_override is set.
+        Ok(self.analyze(&IdfCurve::new(0.0, 1.0, 1.0), &opts)?.pipes)
+    }
+
+    /// Full analysis: Tc accumulation, per-pipe IDF intensity, Rational design
+    /// flows, pipe hydraulics, and an HGL backwater pass with junction losses.
+    pub fn analyze(&self, idf: &IdfCurve, opts: &AnalysisOptions) -> Result<Analysis, NetworkError> {
+        let k = K_MANNING_US;
+        let idxm = self.index();
+        let order = self.topo_order(&idxm)?;
+        let n_nodes = self.nodes.len();
+        let n_pipes = self.pipes.len();
+
+        // Resolve pipe endpoints to node indices once.
+        let pe: Vec<(usize, usize)> = self
+            .pipes
+            .iter()
+            .map(|p| (idxm[p.from.as_str()], idxm[p.to.as_str()]))
+            .collect();
+
+        // incoming[node] = (pipe_idx, upstream_node_idx)
+        let mut incoming: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n_nodes];
+        // outgoing[node] = (pipe_idx, downstream_node_idx)
+        let mut outgoing: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n_nodes];
+        for (pi, &(u, v)) in pe.iter().enumerate() {
+            outgoing[u].push((pi, v));
+            incoming[v].push((pi, u));
+        }
+
+        let ca = self.accumulate_ca()?;
+        let total_ca: Vec<f64> = self.nodes.iter().map(|nd| ca[&nd.id]).collect();
+
+        // Per-pipe scratch.
+        let mut p_slope = vec![0.0f64; n_pipes];
+        let mut p_intensity = vec![0.0f64; n_pipes];
+        let mut p_q = vec![0.0f64; n_pipes];
+        let mut p_vel = vec![0.0f64; n_pipes];
+        let mut p_surch = vec![false; n_pipes];
+        let mut p_yn: Vec<Option<f64>> = vec![None; n_pipes];
+        let mut p_travel = vec![0.0f64; n_pipes];
+        let mut tc_node = vec![0.0f64; n_nodes];
+
+        // ── Forward pass (upstream → downstream): Tc, intensity, design Q, vel.
+        for &i in &order {
+            let nd = &self.nodes[i];
+            let mut tc = if nd.kind == NodeKind::Outfall { 0.0 } else { nd.tc_inlet };
+            for &(pi, _u) in &incoming[i] {
+                tc = tc.max(tc_node[/*upstream*/ pe[pi].0] + p_travel[pi]);
+            }
+            tc = tc.max(opts.min_tc);
+            tc_node[i] = tc;
+
+            for &(pi, v) in &outgoing[i] {
+                let p = &self.pipes[pi];
+                let slope = if p.length > 0.0 {
+                    (self.nodes[i].invert - self.nodes[v].invert) / p.length
+                } else {
+                    0.0
+                };
+                let intensity = opts.intensity_override.unwrap_or_else(|| idf.intensity(tc));
+                let q = intensity * total_ca[i];
+                let (q_max, _) = max_capacity(p.n, slope, p.diameter, k);
+                let surcharged = q > q_max;
+                let yn = normal_depth(q, p.n, slope, p.diameter, k);
+                let area = if surcharged {
+                    full_area(p.diameter)
+                } else {
+                    circular_geometry(yn.unwrap_or(p.diameter), p.diameter).0
+                };
+                let vel = if area > 0.0 { q / area } else { 0.0 };
+                let travel = if vel > 0.0 { p.length / vel / 60.0 } else { 0.0 };
+
+                p_slope[pi] = slope;
+                p_intensity[pi] = intensity;
+                p_q[pi] = q;
+                p_vel[pi] = vel;
+                p_surch[pi] = surcharged;
+                p_yn[pi] = yn;
+                p_travel[pi] = travel;
+            }
+        }
+
+        // ── Backward pass (downstream → upstream): HGL with junction losses.
+        let mut hgl = vec![f64::NAN; n_nodes];
+        let mut pipe_hgl_up = vec![None; n_pipes];
+        let mut pipe_hgl_dn = vec![None; n_pipes];
+
+        for &d in order.iter().rev() {
+            // Seed outfall HGL from tailwater (or free outfall at invert).
+            if self.nodes[d].kind == NodeKind::Outfall && hgl[d].is_nan() {
+                hgl[d] = opts.tailwater.unwrap_or(self.nodes[d].invert);
+            }
+            if hgl[d].is_nan() {
+                hgl[d] = self.nodes[d].invert; // disconnected fallback
+            }
+
+            for &(pi, u) in &incoming[d] {
+                let p = &self.pipes[pi];
+                let dia = p.diameter;
+                let inv_d = self.nodes[d].invert;
+                let inv_u = self.nodes[u].invert;
+                let q = p_q[pi];
+
+                let (ws_d, hf) = if p_surch[pi] {
+                    let conv_full = conveyance(p.n, full_area(dia), dia / 4.0, k);
+                    let sf = if conv_full > 0.0 { (q / conv_full).powi(2) } else { 0.0 };
+                    let crown_d = inv_d + dia;
+                    (hgl[d].max(crown_d), sf * p.length)
+                } else {
+                    let yn = p_yn[pi].unwrap_or(0.0);
+                    let (a, _pp, r, _t) = circular_geometry(yn, dia);
+                    let conv = conveyance(p.n, a, r, k);
+                    let sf = if conv > 0.0 { (q / conv).powi(2) } else { p_slope[pi].max(0.0) };
+                    (hgl[d].max(inv_d + yn), sf * p.length)
+                };
+
+                let yn_u = p_yn[pi].unwrap_or(0.0);
+                let hgl_us_pipe = (ws_d + hf).max(inv_u + yn_u);
+                let hj = opts.junction_k * p_vel[pi].powi(2) / (2.0 * G_US);
+                let hgl_u = hgl_us_pipe + hj;
+
+                hgl[u] = if hgl[u].is_nan() { hgl_u } else { hgl[u].max(hgl_u) };
+                pipe_hgl_dn[pi] = Some(hgl[d]);
+                pipe_hgl_up[pi] = Some(hgl_u);
+            }
+        }
+
+        // ── Assemble results.
+        let pipes = self
+            .pipes
+            .iter()
+            .enumerate()
+            .map(|(pi, p)| {
+                let capacity = full_flow_capacity(p.n, p_slope[pi], p.diameter, k);
+                let velocity_full = if full_area(p.diameter) > 0.0 {
+                    capacity / full_area(p.diameter)
+                } else {
+                    0.0
+                };
+                PipeResult {
+                    id: p.id.clone(),
+                    from: p.from.clone(),
+                    to: p.to.clone(),
+                    slope: p_slope[pi],
+                    total_ca: total_ca[pe[pi].0],
+                    intensity: p_intensity[pi],
+                    tc: tc_node[pe[pi].0],
+                    travel_time: p_travel[pi],
+                    design_q: p_q[pi],
+                    capacity,
+                    max_capacity: max_capacity(p.n, p_slope[pi], p.diameter, k).0,
+                    surcharged: p_surch[pi],
+                    normal_depth: p_yn[pi],
+                    critical_depth: critical_depth(p_q[pi], p.diameter, G_US),
+                    velocity: p_vel[pi],
+                    velocity_full,
+                    pct_full: if capacity > 0.0 { p_q[pi] / capacity } else { 0.0 },
+                    hgl_up: pipe_hgl_up[pi],
+                    hgl_dn: pipe_hgl_dn[pi],
+                }
+            })
+            .collect();
+
+        let nodes = self
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, nd)| NodeResult {
+                id: nd.id.clone(),
+                tc: tc_node[i],
+                hgl: hgl[i],
+                rim: nd.rim,
+                surcharge_to_surface: nd.kind != NodeKind::Outfall && hgl[i] > nd.rim,
+            })
+            .collect();
+
+        Ok(Analysis { pipes, nodes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// N1 (inlet) -> N2 (inlet) -> OUT, two pipes.
+    fn sample() -> Network {
+        Network {
+            nodes: vec![
+                Node::inlet("N1", 100.0, 105.0, 2.0, 0.7), // CA = 1.4
+                Node::inlet("N2", 99.0, 104.0, 3.0, 0.8),  // CA = 2.4
+                Node::outfall("OUT", 98.0, 103.0),
+            ],
+            pipes: vec![
+                Pipe::new("P1", "N1", "N2", 100.0, 1.5, 0.013),
+                Pipe::new("P2", "N2", "OUT", 100.0, 1.5, 0.013),
+            ],
+        }
+    }
+
+    #[test]
+    fn ca_accumulates_downstream() {
+        let ca = sample().accumulate_ca().unwrap();
+        assert!((ca["N1"] - 1.4).abs() < 1e-9);
+        assert!((ca["N2"] - 3.8).abs() < 1e-9);
+        assert!((ca["OUT"] - 3.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rational_design_flows() {
+        let r = sample().analyze_rational(4.0).unwrap();
+        let p1 = r.iter().find(|x| x.id == "P1").unwrap();
+        let p2 = r.iter().find(|x| x.id == "P2").unwrap();
+        assert!((p1.design_q - 5.6).abs() < 1e-6, "P1 {}", p1.design_q);
+        assert!((p2.design_q - 15.2).abs() < 1e-6, "P2 {}", p2.design_q);
+    }
+
+    #[test]
+    fn slope_from_inverts() {
+        let r = sample().analyze_rational(4.0).unwrap();
+        assert!((r[0].slope - 0.01).abs() < 1e-9);
+    }
+
+    #[test]
+    fn small_pipe_surcharges_under_heavy_flow() {
+        let r = sample().analyze_rational(4.0).unwrap();
+        let p1 = r.iter().find(|x| x.id == "P1").unwrap();
+        let p2 = r.iter().find(|x| x.id == "P2").unwrap();
+        assert!(!p1.surcharged, "P1 should fit");
+        assert!(p1.normal_depth.is_some());
+        assert!(p2.surcharged, "P2 should surcharge");
+        assert!(p2.normal_depth.is_none());
+    }
+
+    #[test]
+    fn cycle_is_rejected() {
+        let net = Network {
+            nodes: vec![Node::junction("A", 10.0, 20.0, 0.0, 0.0), Node::junction("B", 9.0, 19.0, 0.0, 0.0)],
+            pipes: vec![Pipe::new("AB", "A", "B", 50.0, 1.0, 0.013), Pipe::new("BA", "B", "A", 50.0, 1.0, 0.013)],
+        };
+        assert_eq!(net.accumulate_ca().unwrap_err(), NetworkError::CyclicNetwork);
+    }
+
+    #[test]
+    fn unknown_node_is_rejected() {
+        let net = Network {
+            nodes: vec![Node::outfall("OUT", 98.0, 103.0)],
+            pipes: vec![Pipe::new("P", "GHOST", "OUT", 100.0, 1.5, 0.013)],
+        };
+        assert!(matches!(net.accumulate_ca().unwrap_err(), NetworkError::UnknownNode(_)));
+    }
+
+    #[test]
+    fn tc_accumulates_downstream() {
+        // Downstream pipe's Tc must include upstream inlet time + travel time.
+        let idf = IdfCurve::new(120.0, 10.0, 0.8);
+        let a = sample().analyze(&idf, &AnalysisOptions::default()).unwrap();
+        let p1 = a.pipes.iter().find(|x| x.id == "P1").unwrap();
+        let p2 = a.pipes.iter().find(|x| x.id == "P2").unwrap();
+        assert!(p2.tc >= p1.tc, "p2.tc {} p1.tc {}", p2.tc, p1.tc);
+        // Intensity falls as Tc grows downstream.
+        assert!(p2.intensity <= p1.intensity, "i2 {} i1 {}", p2.intensity, p1.intensity);
+    }
+
+    #[test]
+    fn hgl_rises_upstream() {
+        // With a tailwater, HGL must be monotonically higher going upstream.
+        let idf = IdfCurve::new(120.0, 10.0, 0.8);
+        let opts = AnalysisOptions { tailwater: Some(100.0), ..Default::default() };
+        let a = sample().analyze(&idf, &opts).unwrap();
+        let h = |id: &str| a.nodes.iter().find(|n| n.id == id).unwrap().hgl;
+        assert!(h("OUT") <= h("N2"), "OUT {} N2 {}", h("OUT"), h("N2"));
+        assert!(h("N2") <= h("N1"), "N2 {} N1 {}", h("N2"), h("N1"));
+        assert!((h("OUT") - 100.0).abs() < 1e-9, "tailwater seeded");
+    }
+}

--- a/crates/stormsewer/src/parse.rs
+++ b/crates/stormsewer/src/parse.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Parser for the `.ssn` storm-sewer network text format.
+//!
+//! Whitespace-delimited; `#` starts a comment. Keywords:
+//!
+//! ```text
+//! IDF <a> <b> <c>                 # IDF curve  i = a/(t+b)^c
+//! INTENSITY <in/hr>               # OR a constant intensity (overrides IDF)
+//! TAILWATER <elev_ft>             # outfall tailwater elevation
+//! MINTC <min>                     # minimum time of concentration
+//! JUNCTIONK <k>                   # junction loss coefficient
+//! NODE <id> <inlet|junction|outfall> <x> <y> <invert> <rim> [area] [C] [tc_inlet]
+//! PIPE <id> <from> <to> <length> <dia> <n>
+//! ```
+//!
+//! For `outfall` nodes the trailing `area`, `C`, and `tc_inlet` are omitted.
+
+use crate::idf::IdfCurve;
+use crate::network::{AnalysisOptions, Network, Node, Pipe};
+
+/// Result of parsing a `.ssn` document.
+#[derive(Clone, Debug)]
+pub struct ParsedNetwork {
+    pub network: Network,
+    pub idf: IdfCurve,
+    pub options: AnalysisOptions,
+}
+
+/// Parse a `.ssn` document. Returns a human-readable error with the line number.
+pub fn parse_ssn(text: &str) -> Result<ParsedNetwork, String> {
+    let mut network = Network::default();
+    let mut idf = IdfCurve::new(120.0, 10.0, 0.8);
+    let mut options = AnalysisOptions::default();
+
+    for (lineno, raw) in text.lines().enumerate() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let t: Vec<&str> = line.split_whitespace().collect();
+        let ln = lineno + 1;
+        let num = |i: usize| -> Result<f64, String> {
+            t.get(i)
+                .ok_or_else(|| format!("line {ln}: missing value #{} in `{line}`", i + 1))?
+                .parse::<f64>()
+                .map_err(|_| format!("line {ln}: `{}` is not a number", t[i]))
+        };
+
+        match t[0].to_ascii_uppercase().as_str() {
+            "IDF" => idf = IdfCurve::new(num(1)?, num(2)?, num(3)?),
+            "INTENSITY" => options.intensity_override = Some(num(1)?),
+            "TAILWATER" => options.tailwater = Some(num(1)?),
+            "MINTC" => options.min_tc = num(1)?,
+            "JUNCTIONK" => options.junction_k = num(1)?,
+            "NODE" => {
+                let id = *t.get(1).ok_or_else(|| format!("line {ln}: NODE needs an id"))?;
+                let kind = t.get(2).ok_or_else(|| format!("line {ln}: NODE needs a kind"))?.to_ascii_lowercase();
+                let (x, y, invert, rim) = (num(3)?, num(4)?, num(5)?, num(6)?);
+                let node = match kind.as_str() {
+                    "outfall" => Node::outfall(id, invert, rim),
+                    "junction" => Node::junction(id, invert, rim, num(7)?, num(8)?),
+                    "inlet" => Node::inlet(id, invert, rim, num(7)?, num(8)?),
+                    other => return Err(format!("line {ln}: unknown node kind `{other}`")),
+                }
+                .at(x, y);
+                let node = if t.len() > 9 { node.with_tc_inlet(num(9)?) } else { node };
+                network.nodes.push(node);
+            }
+            "PIPE" => {
+                let id = *t.get(1).ok_or_else(|| format!("line {ln}: PIPE needs an id"))?;
+                let from = *t.get(2).ok_or_else(|| format!("line {ln}: PIPE needs a from-node"))?;
+                let to = *t.get(3).ok_or_else(|| format!("line {ln}: PIPE needs a to-node"))?;
+                network.pipes.push(Pipe::new(id, from, to, num(4)?, num(5)?, num(6)?));
+            }
+            other => return Err(format!("line {ln}: unknown keyword `{other}`")),
+        }
+    }
+    Ok(ParsedNetwork { network, idf, options })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOC: &str = "\
+# demo
+IDF 60 10 0.8
+TAILWATER 100.5
+NODE N1 inlet    0   0 104 110 1.0 0.70 12
+NODE N2 inlet  300   0 102 108 1.0 0.70
+NODE OUT outfall 600 0 100 106
+PIPE P1 N1 N2 300 1.25 0.013
+PIPE P2 N2 OUT 300 1.50 0.013
+";
+
+    #[test]
+    fn parses_nodes_pipes_and_params() {
+        let p = parse_ssn(DOC).unwrap();
+        assert_eq!(p.network.nodes.len(), 3);
+        assert_eq!(p.network.pipes.len(), 2);
+        assert_eq!(p.options.tailwater, Some(100.5));
+        let n2 = p.network.nodes.iter().find(|n| n.id == "N2").unwrap();
+        assert_eq!((n2.x, n2.y), (300.0, 0.0));
+        assert_eq!(n2.tc_inlet, 10.0); // defaulted (no trailing value)
+        let n1 = p.network.nodes.iter().find(|n| n.id == "N1").unwrap();
+        assert_eq!(n1.tc_inlet, 12.0);
+    }
+
+    #[test]
+    fn analyzes_after_parse() {
+        let p = parse_ssn(DOC).unwrap();
+        let a = p.network.analyze(&p.idf, &p.options).unwrap();
+        assert_eq!(a.pipes.len(), 2);
+    }
+
+    #[test]
+    fn reports_bad_line() {
+        let err = parse_ssn("NODE N1 inlet 0 0 oops 110 1 0.7").unwrap_err();
+        assert!(err.contains("line 1"), "{err}");
+    }
+}

--- a/crates/stormsewer/src/report.rs
+++ b/crates/stormsewer/src/report.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Plain-text report tables for an [`Analysis`], in the spirit of Hydraflow
+//! Storm Sewers' pipe and HGL summaries.
+
+use crate::network::Analysis;
+
+fn f(x: f64, w: usize, p: usize) -> String {
+    format!("{:>w$.p$}", x, w = w, p = p)
+}
+
+/// Format the pipe hydraulics table.
+pub fn pipe_table(a: &Analysis) -> String {
+    let mut s = String::new();
+    s.push_str(
+        "Pipe   From   To     Slope    Tc    i      Q      Cap    %Full  V      yn     HGLup    HGLdn    Status\n",
+    );
+    s.push_str(
+        "                     ft/ft    min   in/hr  cfs    cfs    %      ft/s   ft     ft       ft\n",
+    );
+    s.push_str(&"-".repeat(110));
+    s.push('\n');
+    for p in &a.pipes {
+        let yn = p.normal_depth.map(|y| f(y, 6, 2)).unwrap_or_else(|| "  full".into());
+        let hup = p.hgl_up.map(|h| f(h, 8, 2)).unwrap_or_else(|| "      --".into());
+        let hdn = p.hgl_dn.map(|h| f(h, 8, 2)).unwrap_or_else(|| "      --".into());
+        let status = if p.surcharged { "SURCHARGED" } else { "ok" };
+        s.push_str(&format!(
+            "{:<6} {:<6} {:<6} {} {} {} {} {} {} {} {} {} {}  {}\n",
+            p.id,
+            p.from,
+            p.to,
+            f(p.slope, 7, 4),
+            f(p.tc, 5, 1),
+            f(p.intensity, 6, 2),
+            f(p.design_q, 6, 2),
+            f(p.capacity, 6, 2),
+            f(p.pct_full * 100.0, 6, 1),
+            f(p.velocity, 6, 2),
+            yn,
+            hup,
+            hdn,
+            status,
+        ));
+    }
+    s
+}
+
+/// Format the node / HGL table.
+pub fn node_table(a: &Analysis) -> String {
+    let mut s = String::new();
+    s.push_str("Node   Tc(min)  Rim(ft)   HGL(ft)   Freeboard  Status\n");
+    s.push_str(&"-".repeat(60));
+    s.push('\n');
+    for n in &a.nodes {
+        let fb = n.rim - n.hgl;
+        let status = if n.surcharge_to_surface { "FLOODING" } else { "ok" };
+        s.push_str(&format!(
+            "{:<6} {} {} {} {}  {}\n",
+            n.id,
+            f(n.tc, 7, 1),
+            f(n.rim, 8, 2),
+            f(n.hgl, 8, 2),
+            f(fb, 9, 2),
+            status,
+        ));
+    }
+    s
+}
+
+/// Full report: pipe table followed by node/HGL table.
+pub fn format_analysis(a: &Analysis) -> String {
+    let mut s = String::new();
+    s.push_str("=== STORM SEWER ANALYSIS ===\n\n");
+    s.push_str(&pipe_table(a));
+    s.push('\n');
+    s.push_str(&node_table(a));
+    // Summary flags.
+    let surcharged: Vec<&str> = a.pipes.iter().filter(|p| p.surcharged).map(|p| p.id.as_str()).collect();
+    let flooding: Vec<&str> = a.nodes.iter().filter(|n| n.surcharge_to_surface).map(|n| n.id.as_str()).collect();
+    s.push('\n');
+    if surcharged.is_empty() && flooding.is_empty() {
+        s.push_str("All pipes flow open-channel; no surface flooding.\n");
+    } else {
+        if !surcharged.is_empty() {
+            s.push_str(&format!("Surcharged pipes: {}\n", surcharged.join(", ")));
+        }
+        if !flooding.is_empty() {
+            s.push_str(&format!("Structures flooding (HGL > rim): {}\n", flooding.join(", ")));
+        }
+    }
+    s
+}

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -68,14 +68,11 @@ impl OpenCADStudio {
                 };
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
-                // Focus the command line so the first typed value is captured.
-                return self.focus_cmd_input();
             }
             "SS_PIPE" => {
                 let cmd = crate::modules::storm_sewer::structures::PlacePipe::new();
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
-                return self.focus_cmd_input();
             }
             "SS_PROFILE" => {
                 use crate::modules::storm_sewer::analysis as ss;

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -68,11 +68,14 @@ impl OpenCADStudio {
                 };
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
+                // Focus the command line so the first typed value is captured.
+                return self.focus_cmd_input();
             }
             "SS_PIPE" => {
                 let cmd = crate::modules::storm_sewer::structures::PlacePipe::new();
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
+                return self.focus_cmd_input();
             }
             "SS_PROFILE" => {
                 use crate::modules::storm_sewer::analysis as ss;

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -32,34 +32,31 @@ impl OpenCADStudio {
             // ── Storm Sewer module ──────────────────────────────────────────
             "SS_ANALYZE" => {
                 use crate::modules::storm_sewer::analysis as ss;
-                match ss::pick_ssn_file() {
-                    Some(read) => match read.and_then(|t| ss::analyze_text(&t)) {
-                        Ok((ents, report)) => {
-                            for e in ents {
-                                let _ = self.tabs[i].scene.add_entity(e);
-                            }
-                            self.tabs[i].scene.bump_geometry();
-                            for line in report.lines() {
-                                self.command_line.push_output(line);
-                            }
+                let result = ss::analyze_doc(self.tabs[i].scene.document.entities());
+                match result {
+                    Ok((ents, report)) => {
+                        for e in ents {
+                            let _ = self.tabs[i].scene.add_entity(e);
                         }
-                        Err(e) => self.command_line.push_error(&e),
-                    },
-                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                        self.tabs[i].scene.bump_geometry();
+                        self.command_line
+                            .push_info("Storm sewer: analyzed drawn network (default IDF 60/(t+10)^0.8).");
+                        for line in report.lines() {
+                            self.command_line.push_output(line);
+                        }
+                    }
+                    Err(e) => self.command_line.push_error(&e),
                 }
             }
             "SS_REPORT" => {
                 use crate::modules::storm_sewer::analysis as ss;
-                match ss::pick_ssn_file() {
-                    Some(read) => match read.and_then(|t| ss::report_text_from(&t)) {
-                        Ok(report) => {
-                            for line in report.lines() {
-                                self.command_line.push_output(line);
-                            }
+                match ss::report_doc(self.tabs[i].scene.document.entities()) {
+                    Ok(report) => {
+                        for line in report.lines() {
+                            self.command_line.push_output(line);
                         }
-                        Err(e) => self.command_line.push_error(&e),
-                    },
-                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                    }
+                    Err(e) => self.command_line.push_error(&e),
                 }
             }
             "SS_INLET" | "SS_JUNCTION" | "SS_OUTFALL" => {
@@ -79,18 +76,16 @@ impl OpenCADStudio {
             }
             "SS_PROFILE" => {
                 use crate::modules::storm_sewer::analysis as ss;
-                match ss::pick_ssn_file() {
-                    Some(read) => match read.and_then(|t| ss::profile_text(&t)) {
-                        Ok(ents) => {
-                            for e in ents {
-                                let _ = self.tabs[i].scene.add_entity(e);
-                            }
-                            self.tabs[i].scene.bump_geometry();
-                            self.command_line.push_info("Storm sewer HGL profile drawn.");
+                let result = ss::profile_doc(self.tabs[i].scene.document.entities());
+                match result {
+                    Ok(ents) => {
+                        for e in ents {
+                            let _ = self.tabs[i].scene.add_entity(e);
                         }
-                        Err(e) => self.command_line.push_error(&e),
-                    },
-                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                        self.tabs[i].scene.bump_geometry();
+                        self.command_line.push_info("Storm sewer HGL profile drawn.");
+                    }
+                    Err(e) => self.command_line.push_error(&e),
                 }
             }
             "NEW" => return Task::done(Message::TabNew),

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -29,6 +29,70 @@ impl OpenCADStudio {
         }
 
         match cmd {
+            // ── Storm Sewer module ──────────────────────────────────────────
+            "SS_ANALYZE" => {
+                use crate::modules::storm_sewer::analysis as ss;
+                match ss::pick_ssn_file() {
+                    Some(read) => match read.and_then(|t| ss::analyze_text(&t)) {
+                        Ok((ents, report)) => {
+                            for e in ents {
+                                let _ = self.tabs[i].scene.add_entity(e);
+                            }
+                            self.tabs[i].scene.bump_geometry();
+                            for line in report.lines() {
+                                self.command_line.push_output(line);
+                            }
+                        }
+                        Err(e) => self.command_line.push_error(&e),
+                    },
+                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                }
+            }
+            "SS_REPORT" => {
+                use crate::modules::storm_sewer::analysis as ss;
+                match ss::pick_ssn_file() {
+                    Some(read) => match read.and_then(|t| ss::report_text_from(&t)) {
+                        Ok(report) => {
+                            for line in report.lines() {
+                                self.command_line.push_output(line);
+                            }
+                        }
+                        Err(e) => self.command_line.push_error(&e),
+                    },
+                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                }
+            }
+            "SS_INLET" | "SS_JUNCTION" | "SS_OUTFALL" => {
+                use crate::modules::storm_sewer::structures::PlaceStructure;
+                let cmd = match cmd {
+                    "SS_INLET" => PlaceStructure::inlet(),
+                    "SS_JUNCTION" => PlaceStructure::junction(),
+                    _ => PlaceStructure::outfall(),
+                };
+                self.command_line.push_info(&cmd.prompt());
+                self.tabs[i].active_cmd = Some(Box::new(cmd));
+            }
+            "SS_PIPE" => {
+                let cmd = crate::modules::storm_sewer::structures::PlacePipe::new();
+                self.command_line.push_info(&cmd.prompt());
+                self.tabs[i].active_cmd = Some(Box::new(cmd));
+            }
+            "SS_PROFILE" => {
+                use crate::modules::storm_sewer::analysis as ss;
+                match ss::pick_ssn_file() {
+                    Some(read) => match read.and_then(|t| ss::profile_text(&t)) {
+                        Ok(ents) => {
+                            for e in ents {
+                                let _ = self.tabs[i].scene.add_entity(e);
+                            }
+                            self.tabs[i].scene.bump_geometry();
+                            self.command_line.push_info("Storm sewer HGL profile drawn.");
+                        }
+                        Err(e) => self.command_line.push_error(&e),
+                    },
+                    None => self.command_line.push_info("Storm sewer: open cancelled."),
+                }
+            }
             "NEW" => return Task::done(Message::TabNew),
             "OPEN" => return Task::done(Message::OpenFile),
             "SAVE" | "QSAVE" => return Task::done(Message::SaveFile),

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -2812,7 +2812,7 @@ impl OpenCADStudio {
                                     .map(|c| {
                                         matches!(
                                             c.name(),
-                                            "DIMTEDIT" | "MLEADERADD" | "MLEADERREMOVE" | "SS_PIPE"
+                                            "DIMTEDIT" | "MLEADERADD" | "MLEADERREMOVE"
                                         )
                                     })
                                     .unwrap_or(false);

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -2812,7 +2812,7 @@ impl OpenCADStudio {
                                     .map(|c| {
                                         matches!(
                                             c.name(),
-                                            "DIMTEDIT" | "MLEADERADD" | "MLEADERREMOVE"
+                                            "DIMTEDIT" | "MLEADERADD" | "MLEADERREMOVE" | "SS_PIPE"
                                         )
                                     })
                                     .unwrap_or(false);

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -137,6 +137,7 @@ pub mod insert;
 pub mod model;
 pub mod layout;
 pub mod manage;
+pub mod storm_sewer;
 pub mod view;
 
 // ── Auto-generated module registry ───────────────────────────────────────

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -14,5 +14,6 @@ pub fn all_modules() -> Vec<Box<dyn CadModule>> {
 		Box::new(super::view::ViewModule),
 		Box::new(super::manage::ManageModule),
 		Box::new(super::layout::LayoutModule),
+		Box::new(super::storm_sewer::StormSewerModule),
 	]
 }

--- a/src/modules/storm_sewer/INTEGRATION.md
+++ b/src/modules/storm_sewer/INTEGRATION.md
@@ -34,18 +34,26 @@ All `SS_*` commands are wired in `src/app/commands.rs::dispatch_command`:
 
 | Command   | Status | Action |
 |-----------|--------|--------|
-| `SS_INLET`/`SS_JUNCTION`/`SS_OUTFALL` | ✅ done | `PlaceStructure` — pick a point, then prompt invert/rim/area/C; commits an XDATA-tagged circle |
-| `SS_PIPE` | ✅ done | `PlacePipe` — pick START + END structures (snaps to their centers via entity-pick), prompt diameter/n; commits an XDATA-tagged line with connectivity |
+| `SS_INLET`/`SS_JUNCTION`/`SS_OUTFALL` | ✅ done | `PlaceStructure` — enter invert/rim/area/C, then click the location; commits an XDATA-tagged circle |
+| `SS_PIPE` | ✅ done | `PlacePipe` — enter diameter/n, then click the START and END structures; commits an XDATA-tagged line (endpoints at the clicks, connectivity by structure handle) |
 | `SS_ANALYZE` | ✅ done | rebuild the network from drawn entities → run engine → add flow/HGL labels + print report |
 | `SS_REPORT` | ✅ done | rebuild from drawn entities → print `report::format_analysis()` |
 | `SS_PROFILE` | ✅ done | rebuild from drawn entities → draw the HGL/invert/ground long-section |
 
-`SS_PIPE` requires its name in the `inject_picked_entity` allow-list in
-`src/app/update.rs` (so it receives the picked structure to read its center).
+**Interaction order matters.** Both commands collect typed values FIRST (the
+command line is focused via `focus_cmd_input()` at dispatch and stays focused
+through text input), then take the viewport click LAST and commit from it. A
+point-pick result (`NeedPoint`) does not re-focus the command line, so a
+click-then-type flow would lose focus and route Enter to `on_enter` → cancel.
 
 The `.ssn` file path is retained in `analysis.rs` (`analyze_text` etc.) for
 file-based workflows and tests, but the ribbon commands now operate on the
 **drawn network**.
+
+Snapping note: pipe endpoints land at the click points (where you click on each
+structure). Connectivity is exact (by handle) and analysis uses the structure
+centers, so the analysis is correct; a future refinement could redraw pipes
+exactly center-to-center.
 
 ## Remaining enhancements
 

--- a/src/modules/storm_sewer/INTEGRATION.md
+++ b/src/modules/storm_sewer/INTEGRATION.md
@@ -1,0 +1,56 @@
+# Storm Sewer module — integration plan
+
+The ribbon tab (`mod.rs`) and the engine bridge (`analysis.rs`) are in place.
+What remains is wiring each `SS_*` ribbon command to a handler in the host
+command system.
+
+## Architecture
+
+```
+storm_sewer/mod.rs      ribbon tab  →  emits ModuleEvent::Command("SS_*")
+        │
+host command dispatch   (src/app/commands.rs / src/command/)
+        │
+storm_sewer/analysis.rs builds a stormsewer::Network and runs the engine
+        │
+stormsewer crate        Rational + Manning + HGL  →  Analysis + report text
+```
+
+The network/hydraulics data is **not** a native `acadrust` entity, so it is
+carried as side data keyed to drawing entities:
+
+| Network object | Drawing representation | XDATA / fields |
+|----------------|------------------------|----------------|
+| Node (inlet/junction/outfall) | block insert at the structure point | invert, rim, area_ac, C, tc_inlet, kind |
+| Pipe (link) | LINE/LWPOLYLINE between two structures | diameter, n (length from geometry) |
+
+## Command handlers — status
+
+All `SS_*` commands are wired in `src/app/commands.rs::dispatch_command`:
+
+| Command   | Status | Action |
+|-----------|--------|--------|
+| `SS_INLET`/`SS_JUNCTION`/`SS_OUTFALL` | ✅ done | interactive `PlaceStructure` — pick points, drop circle markers (repeatable) |
+| `SS_PIPE` | ✅ done | interactive `PlacePipe` — chain line segments between structures |
+| `SS_ANALYZE` | ✅ done | open a `.ssn` file → run engine → draw plan (pipes/markers/labels) + print report |
+| `SS_REPORT` | ✅ done | open a `.ssn` file → print `report::format_analysis()` to the command line |
+| `SS_PROFILE` | ✅ done | open a `.ssn` file → draw the HGL/invert/ground long-section of the main stem |
+
+Drafting (`structures.rs`) and analysis/drawing (`analysis.rs`) are both live and
+unit-tested. `SS_ANALYZE`/`SS_REPORT`/`SS_PROFILE` read a user-authored `.ssn`
+network file (format in `stormsewer::parse`); the engine runs on real data.
+
+## Remaining enhancement: drive analysis from canvas geometry
+
+The placement commands (`SS_INLET`/`PIPE`/…) draw markers and pipe lines but do
+not yet carry hydraulic data, so analysis is driven by the `.ssn` file rather
+than by the drawn entities. To let users analyze what they draw directly, attach
+data via **XDATA** when `PlaceStructure`/`PlacePipe` commit (invert/rim/area/C on
+structures, diameter/n on pipes), then have `SS_ANALYZE` walk the document
+entities into a `stormsewer::Network`. The `.ssn` path remains the simple,
+file-based workflow.
+
+## Build
+
+`build.rs` auto-discovers this directory (`storm_sewer/` → `StormSewerModule`)
+and regenerates `src/modules/registry.rs`, so the tab appears on `cargo build`.

--- a/src/modules/storm_sewer/INTEGRATION.md
+++ b/src/modules/storm_sewer/INTEGRATION.md
@@ -16,13 +16,17 @@ storm_sewer/analysis.rs builds a stormsewer::Network and runs the engine
 stormsewer crate        Rational + Manning + HGL  →  Analysis + report text
 ```
 
-The network/hydraulics data is **not** a native `acadrust` entity, so it is
-carried as side data keyed to drawing entities:
+The network/hydraulics data is carried as **XDATA on the drawing entities**
+(`data.rs`), so the network round-trips to DWG/DXF and is analyzable directly:
 
-| Network object | Drawing representation | XDATA / fields |
-|----------------|------------------------|----------------|
-| Node (inlet/junction/outfall) | block insert at the structure point | invert, rim, area_ac, C, tc_inlet, kind |
-| Pipe (link) | LINE/LWPOLYLINE between two structures | diameter, n (length from geometry) |
+| Network object | Entity | XDATA record `STORMSEWER_*` |
+|----------------|--------|------------------------------|
+| Structure (inlet/junction/outfall) | CIRCLE at the point | `STRUCT`: [kind, invert, rim, area, C] |
+| Pipe (link) | LINE between two structures | `PIPE`: [diameter, n, from-handle, to-handle] |
+
+Connectivity is by entity handle: a pipe stores the handles of the two
+structures it connects, so `data::network_from_entities` rebuilds the
+`stormsewer::Network` (nodes N1, N2, … by encounter order) from the drawing.
 
 ## Command handlers — status
 
@@ -30,25 +34,27 @@ All `SS_*` commands are wired in `src/app/commands.rs::dispatch_command`:
 
 | Command   | Status | Action |
 |-----------|--------|--------|
-| `SS_INLET`/`SS_JUNCTION`/`SS_OUTFALL` | ✅ done | interactive `PlaceStructure` — pick points, drop circle markers (repeatable) |
-| `SS_PIPE` | ✅ done | interactive `PlacePipe` — chain line segments between structures |
-| `SS_ANALYZE` | ✅ done | open a `.ssn` file → run engine → draw plan (pipes/markers/labels) + print report |
-| `SS_REPORT` | ✅ done | open a `.ssn` file → print `report::format_analysis()` to the command line |
-| `SS_PROFILE` | ✅ done | open a `.ssn` file → draw the HGL/invert/ground long-section of the main stem |
+| `SS_INLET`/`SS_JUNCTION`/`SS_OUTFALL` | ✅ done | `PlaceStructure` — pick a point, then prompt invert/rim/area/C; commits an XDATA-tagged circle |
+| `SS_PIPE` | ✅ done | `PlacePipe` — pick START + END structures (snaps to their centers via entity-pick), prompt diameter/n; commits an XDATA-tagged line with connectivity |
+| `SS_ANALYZE` | ✅ done | rebuild the network from drawn entities → run engine → add flow/HGL labels + print report |
+| `SS_REPORT` | ✅ done | rebuild from drawn entities → print `report::format_analysis()` |
+| `SS_PROFILE` | ✅ done | rebuild from drawn entities → draw the HGL/invert/ground long-section |
 
-Drafting (`structures.rs`) and analysis/drawing (`analysis.rs`) are both live and
-unit-tested. `SS_ANALYZE`/`SS_REPORT`/`SS_PROFILE` read a user-authored `.ssn`
-network file (format in `stormsewer::parse`); the engine runs on real data.
+`SS_PIPE` requires its name in the `inject_picked_entity` allow-list in
+`src/app/update.rs` (so it receives the picked structure to read its center).
 
-## Remaining enhancement: drive analysis from canvas geometry
+The `.ssn` file path is retained in `analysis.rs` (`analyze_text` etc.) for
+file-based workflows and tests, but the ribbon commands now operate on the
+**drawn network**.
 
-The placement commands (`SS_INLET`/`PIPE`/…) draw markers and pipe lines but do
-not yet carry hydraulic data, so analysis is driven by the `.ssn` file rather
-than by the drawn entities. To let users analyze what they draw directly, attach
-data via **XDATA** when `PlaceStructure`/`PlacePipe` commit (invert/rim/area/C on
-structures, diameter/n on pipes), then have `SS_ANALYZE` walk the document
-entities into a `stormsewer::Network`. The `.ssn` path remains the simple,
-file-based workflow.
+## Remaining enhancements
+
+- **Rainfall parameters UI** — `SS_ANALYZE` uses a default IDF (`60/(t+10)^0.8`)
+  and free outfall; add an `SS_PARAMS` command to set IDF / tailwater / min-Tc.
+- **Edit command** — `SS_EDIT` to change a placed structure/pipe's values.
+- **Surcharge styling** — recolor surcharged pipes / flag flooded structures.
+- **Persistence check** — verify the StormSewer XDATA round-trips through
+  DWG/DXF save+reload (acadrust supports XDATA; confirm end-to-end).
 
 ## Build
 

--- a/src/modules/storm_sewer/analysis.rs
+++ b/src/modules/storm_sewer/analysis.rs
@@ -14,6 +14,51 @@ use stormsewer::network::{Analysis, AnalysisOptions, Network, Node, Pipe};
 use stormsewer::parse::parse_ssn;
 use stormsewer::report::format_analysis;
 
+use super::data;
+
+/// Default network-level analysis parameters used when analyzing a drawn
+/// network (per-entity data carries geometry/area; rainfall is global).
+fn default_params() -> (IdfCurve, AnalysisOptions) {
+    (IdfCurve::new(60.0, 10.0, 0.8), AnalysisOptions::default())
+}
+
+/// Annotation labels only (flow + HGL), for overlaying on an already-drawn
+/// network without re-drawing its geometry.
+fn build_annotations(net: &Network, a: &Analysis) -> Vec<EntityType> {
+    draw_network(net, a, &DrawConfig::default())
+        .plan_labels
+        .iter()
+        .map(|l| label(l.x, l.y, l.text.clone(), l.height))
+        .collect()
+}
+
+// ── Public API: analyze the network drawn in the active document ────────────
+
+/// Reconstruct the network from drawn entities, analyze it, and return
+/// annotation entities (flow/HGL labels) + the report.
+pub fn analyze_doc<'a>(entities: impl Iterator<Item = &'a EntityType>) -> Result<(Vec<EntityType>, String), String> {
+    let net = data::network_from_entities(entities)?;
+    let (idf, opts) = default_params();
+    let a = run_analysis(&net, &idf, &opts)?;
+    Ok((build_annotations(&net, &a), format_analysis(&a)))
+}
+
+/// Reconstruct from drawn entities and return the HGL long-section entities.
+pub fn profile_doc<'a>(entities: impl Iterator<Item = &'a EntityType>) -> Result<Vec<EntityType>, String> {
+    let net = data::network_from_entities(entities)?;
+    let (idf, opts) = default_params();
+    let a = run_analysis(&net, &idf, &opts)?;
+    Ok(build_profile(&net, &a))
+}
+
+/// Reconstruct from drawn entities and return the formatted report.
+pub fn report_doc<'a>(entities: impl Iterator<Item = &'a EntityType>) -> Result<String, String> {
+    let net = data::network_from_entities(entities)?;
+    let (idf, opts) = default_params();
+    let a = run_analysis(&net, &idf, &opts)?;
+    Ok(format_analysis(&a))
+}
+
 /// The built-in demonstration network (properly sized, with plan coordinates).
 fn demo() -> (Network, IdfCurve, AnalysisOptions) {
     let net = Network {

--- a/src/modules/storm_sewer/analysis.rs
+++ b/src/modules/storm_sewer/analysis.rs
@@ -1,0 +1,152 @@
+// Bridge between Open CAD Studio and the `stormsewer` engine crate.
+//
+// Runs the hydrology/hydraulics engine on a network and turns the result into
+// (a) acadrust entities to draw into the document and (b) a text report for the
+// command line. Networks come from a `.ssn` file (see `stormsewer::parse`); a
+// built-in sample backs the unit tests and the zero-argument fallbacks.
+
+use acadrust::types::Vector3;
+use acadrust::{Circle, EntityType, Line, MText};
+
+use stormsewer::drawing::{draw_network, DrawConfig};
+use stormsewer::idf::IdfCurve;
+use stormsewer::network::{Analysis, AnalysisOptions, Network, Node, Pipe};
+use stormsewer::parse::parse_ssn;
+use stormsewer::report::format_analysis;
+
+/// The built-in demonstration network (properly sized, with plan coordinates).
+fn demo() -> (Network, IdfCurve, AnalysisOptions) {
+    let net = Network {
+        nodes: vec![
+            Node::inlet("N1", 104.0, 110.0, 1.0, 0.70).with_tc_inlet(12.0).at(0.0, 0.0),
+            Node::inlet("N2", 102.5, 108.5, 1.0, 0.70).with_tc_inlet(10.0).at(300.0, 0.0),
+            Node::junction("N3", 101.2, 107.0, 0.5, 0.80).with_tc_inlet(8.0).at(550.0, 0.0),
+            Node::outfall("OUT", 100.0, 106.0).at(730.0, 0.0),
+        ],
+        pipes: vec![
+            Pipe::new("P1", "N1", "N2", 300.0, 1.25, 0.013),
+            Pipe::new("P2", "N2", "N3", 250.0, 1.50, 0.013),
+            Pipe::new("P3", "N3", "OUT", 180.0, 1.75, 0.013),
+        ],
+    };
+    let idf = IdfCurve::new(60.0, 10.0, 0.8);
+    let opts = AnalysisOptions { tailwater: Some(100.5), ..Default::default() };
+    (net, idf, opts)
+}
+
+fn v3(x: f64, y: f64) -> Vector3 {
+    Vector3::new(x, y, 0.0)
+}
+
+fn seg(x1: f64, y1: f64, x2: f64, y2: f64) -> EntityType {
+    EntityType::Line(Line::from_points(v3(x1, y1), v3(x2, y2)))
+}
+
+fn label(x: f64, y: f64, text: String, height: f64) -> EntityType {
+    EntityType::MText(MText { value: text, insertion_point: v3(x, y), height, ..Default::default() })
+}
+
+fn circle(x: f64, y: f64, r: f64) -> EntityType {
+    EntityType::Circle(Circle { center: v3(x, y), radius: r, ..Default::default() })
+}
+
+fn run_analysis(net: &Network, idf: &IdfCurve, opts: &AnalysisOptions) -> Result<Analysis, String> {
+    net.analyze(idf, opts).map_err(|e| e.to_string())
+}
+
+/// Plan-view entities (pipes, structure markers, flow/HGL labels) + the report.
+fn build_plan(net: &Network, a: &Analysis) -> (Vec<EntityType>, String) {
+    let d = draw_network(net, a, &DrawConfig::default());
+    let mut ents = Vec::new();
+    for p in &d.plan_pipes {
+        ents.push(seg(p.x1, p.y1, p.x2, p.y2));
+    }
+    for n in &d.plan_nodes {
+        ents.push(circle(n.x, n.y, n.radius));
+    }
+    for l in &d.plan_labels {
+        ents.push(label(l.x, l.y, l.text.clone(), l.height));
+    }
+    (ents, format_analysis(a))
+}
+
+/// HGL long-section entities (ground / invert / HGL polylines + labels).
+fn build_profile(net: &Network, a: &Analysis) -> Vec<EntityType> {
+    let d = draw_network(net, a, &DrawConfig::default());
+    let mut ents = Vec::new();
+    for pl in &d.profile_lines {
+        for w in pl.pts.windows(2) {
+            ents.push(seg(w[0].0, w[0].1, w[1].0, w[1].1));
+        }
+    }
+    for l in &d.profile_labels {
+        ents.push(label(l.x, l.y, l.text.clone(), l.height));
+    }
+    ents
+}
+
+// ── Public API: from a `.ssn` document ──────────────────────────────────────
+
+/// Open a file dialog and read a `.ssn` network file.
+///
+/// Returns `None` if the user cancels, `Some(Ok(text))` on success, or
+/// `Some(Err(msg))` if the chosen file cannot be read.
+pub fn pick_ssn_file() -> Option<Result<String, String>> {
+    let path = rfd::FileDialog::new()
+        .add_filter("Storm Sewer Network", &["ssn"])
+        .set_title("Open storm-sewer network (.ssn)")
+        .pick_file()?;
+    Some(std::fs::read_to_string(&path).map_err(|e| format!("cannot read {}: {e}", path.display())))
+}
+
+/// Parse a `.ssn` document, analyze it, and return (plan entities, report).
+pub fn analyze_text(text: &str) -> Result<(Vec<EntityType>, String), String> {
+    let p = parse_ssn(text)?;
+    let a = run_analysis(&p.network, &p.idf, &p.options)?;
+    Ok(build_plan(&p.network, &a))
+}
+
+/// Parse a `.ssn` document, analyze it, and return the HGL profile entities.
+pub fn profile_text(text: &str) -> Result<Vec<EntityType>, String> {
+    let p = parse_ssn(text)?;
+    let a = run_analysis(&p.network, &p.idf, &p.options)?;
+    Ok(build_profile(&p.network, &a))
+}
+
+/// Parse a `.ssn` document, analyze it, and return the formatted report.
+pub fn report_text_from(text: &str) -> Result<String, String> {
+    let p = parse_ssn(text)?;
+    let a = run_analysis(&p.network, &p.idf, &p.options)?;
+    Ok(format_analysis(&a))
+}
+
+// ── Built-in sample fallbacks (used by tests) ───────────────────────────────
+
+/// Plan entities + report for the built-in sample network.
+pub fn analyze_plan() -> Result<(Vec<EntityType>, String), String> {
+    let (net, idf, opts) = demo();
+    let a = run_analysis(&net, &idf, &opts)?;
+    Ok(build_plan(&net, &a))
+}
+
+/// Profile entities for the built-in sample network.
+pub fn analyze_profile() -> Result<Vec<EntityType>, String> {
+    let (net, idf, opts) = demo();
+    let a = run_analysis(&net, &idf, &opts)?;
+    Ok(build_profile(&net, &a))
+}
+
+/// Formatted report for the built-in sample network.
+pub fn report_text() -> String {
+    let (net, idf, opts) = demo();
+    match run_analysis(&net, &idf, &opts) {
+        Ok(a) => format_analysis(&a),
+        Err(e) => format!("storm-sewer analysis error: {e}"),
+    }
+}
+
+/// Back-compat alias used by the module's integration test.
+#[allow(dead_code)]
+pub fn demo_report() -> String {
+    report_text()
+}

--- a/src/modules/storm_sewer/data.rs
+++ b/src/modules/storm_sewer/data.rs
@@ -1,0 +1,236 @@
+// Storm-sewer data carried on drawing entities via XDATA, and reconstruction
+// of a `stormsewer::Network` from the drawn entities.
+//
+// Structures are circles tagged with the `STORMSEWER_STRUCT` app record
+// [kind, invert, rim, area, C]; pipes are lines tagged with `STORMSEWER_PIPE`
+// [diameter, n, from-handle, to-handle]. Connectivity is by entity handle, so
+// the drawn network round-trips to DWG/DXF and is analyzable directly.
+
+use std::collections::HashMap;
+
+use acadrust::xdata::{ExtendedDataRecord, XDataValue};
+use acadrust::{EntityType, Handle};
+
+use stormsewer::network::{Network, Node, NodeKind, Pipe};
+
+pub const APP_STRUCT: &str = "STORMSEWER_STRUCT";
+pub const APP_PIPE: &str = "STORMSEWER_PIPE";
+
+pub fn kind_str(k: NodeKind) -> &'static str {
+    match k {
+        NodeKind::Inlet => "inlet",
+        NodeKind::Junction => "junction",
+        NodeKind::Outfall => "outfall",
+    }
+}
+
+fn parse_kind(s: &str) -> NodeKind {
+    match s {
+        "outfall" => NodeKind::Outfall,
+        "junction" => NodeKind::Junction,
+        _ => NodeKind::Inlet,
+    }
+}
+
+/// XDATA record for a structure marker.
+pub fn structure_xdata(kind: NodeKind, invert: f64, rim: f64, area: f64, c: f64) -> ExtendedDataRecord {
+    let mut r = ExtendedDataRecord::new(APP_STRUCT);
+    r.add_value(XDataValue::String(kind_str(kind).to_string()));
+    r.add_value(XDataValue::Real(invert));
+    r.add_value(XDataValue::Real(rim));
+    r.add_value(XDataValue::Real(area));
+    r.add_value(XDataValue::Real(c));
+    r
+}
+
+/// XDATA record for a pipe, linking the two structures it connects by handle.
+pub fn pipe_xdata(diameter: f64, n: f64, from: Handle, to: Handle) -> ExtendedDataRecord {
+    let mut r = ExtendedDataRecord::new(APP_PIPE);
+    r.add_value(XDataValue::Real(diameter));
+    r.add_value(XDataValue::Real(n));
+    r.add_value(XDataValue::Handle(from));
+    r.add_value(XDataValue::Handle(to));
+    r
+}
+
+fn real(v: &XDataValue) -> Option<f64> {
+    if let XDataValue::Real(x) = v {
+        Some(*x)
+    } else {
+        None
+    }
+}
+
+fn handle(v: &XDataValue) -> Option<Handle> {
+    if let XDataValue::Handle(h) = v {
+        Some(*h)
+    } else {
+        None
+    }
+}
+
+struct StructRec {
+    handle: Handle,
+    kind: NodeKind,
+    invert: f64,
+    rim: f64,
+    area: f64,
+    c: f64,
+    x: f64,
+    y: f64,
+}
+
+struct PipeRec {
+    diameter: f64,
+    n: f64,
+    from: Handle,
+    to: Handle,
+    length: f64,
+}
+
+fn read_structure(e: &EntityType) -> Option<StructRec> {
+    let rec = e.common().extended_data.get_record(APP_STRUCT)?;
+    if rec.values.len() < 5 {
+        return None;
+    }
+    let kind = match &rec.values[0] {
+        XDataValue::String(s) => parse_kind(s),
+        _ => return None,
+    };
+    let (x, y) = match e {
+        EntityType::Circle(c) => (c.center.x, c.center.y),
+        _ => return None,
+    };
+    Some(StructRec {
+        handle: e.common().handle,
+        kind,
+        invert: real(&rec.values[1])?,
+        rim: real(&rec.values[2])?,
+        area: real(&rec.values[3])?,
+        c: real(&rec.values[4])?,
+        x,
+        y,
+    })
+}
+
+fn read_pipe(e: &EntityType) -> Option<PipeRec> {
+    let rec = e.common().extended_data.get_record(APP_PIPE)?;
+    if rec.values.len() < 4 {
+        return None;
+    }
+    let length = match e {
+        EntityType::Line(l) => {
+            let dx = l.end.x - l.start.x;
+            let dy = l.end.y - l.start.y;
+            (dx * dx + dy * dy).sqrt()
+        }
+        _ => return None,
+    };
+    Some(PipeRec {
+        diameter: real(&rec.values[0])?,
+        n: real(&rec.values[1])?,
+        from: handle(&rec.values[2])?,
+        to: handle(&rec.values[3])?,
+        length,
+    })
+}
+
+/// Build a `stormsewer::Network` from drawn entities. Structures become nodes
+/// (named N1, N2, … in encounter order); pipes become links, mapped to nodes
+/// by the handles stored in their XDATA.
+pub fn network_from_entities<'a>(entities: impl Iterator<Item = &'a EntityType>) -> Result<Network, String> {
+    let mut structs: Vec<StructRec> = Vec::new();
+    let mut pipes_raw: Vec<PipeRec> = Vec::new();
+    for e in entities {
+        if let Some(s) = read_structure(e) {
+            structs.push(s);
+        } else if let Some(p) = read_pipe(e) {
+            pipes_raw.push(p);
+        }
+    }
+    if structs.is_empty() {
+        return Err("No storm-sewer structures in the drawing — place Inlet/Junction/Outfall first.".into());
+    }
+
+    let mut id_of: HashMap<u64, String> = HashMap::new();
+    let mut nodes = Vec::with_capacity(structs.len());
+    for (idx, s) in structs.iter().enumerate() {
+        let id = format!("N{}", idx + 1);
+        id_of.insert(s.handle.value(), id.clone());
+        let node = match s.kind {
+            NodeKind::Inlet => Node::inlet(&id, s.invert, s.rim, s.area, s.c),
+            NodeKind::Junction => Node::junction(&id, s.invert, s.rim, s.area, s.c),
+            NodeKind::Outfall => Node::outfall(&id, s.invert, s.rim),
+        }
+        .at(s.x, s.y);
+        nodes.push(node);
+    }
+
+    let mut pipes = Vec::new();
+    let mut dropped = 0;
+    for (k, p) in pipes_raw.iter().enumerate() {
+        match (id_of.get(&p.from.value()), id_of.get(&p.to.value())) {
+            (Some(f), Some(t)) => {
+                pipes.push(Pipe::new(&format!("P{}", k + 1), f, t, p.length, p.diameter, p.n));
+            }
+            _ => dropped += 1,
+        }
+    }
+    if pipes.is_empty() {
+        return Err(format!(
+            "No connected storm-sewer pipes ({} structure(s) found, {} dangling pipe(s)). Use Pipe Run to connect structures.",
+            structs.len(), dropped
+        ));
+    }
+    Ok(Network { nodes, pipes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acadrust::types::Vector3;
+    use acadrust::{Circle, Line};
+
+    fn structure(h: u64, kind: NodeKind, x: f64, invert: f64) -> EntityType {
+        let mut e = EntityType::Circle(Circle { center: Vector3::new(x, 0.0, 0.0), radius: 3.0, ..Default::default() });
+        e.common_mut().handle = Handle::new(h);
+        e.common_mut().extended_data.add_record(structure_xdata(kind, invert, invert + 6.0, 1.0, 0.7));
+        e
+    }
+    fn pipe(from: u64, to: u64, x1: f64, x2: f64) -> EntityType {
+        let mut e = EntityType::Line(Line::from_points(Vector3::new(x1, 0.0, 0.0), Vector3::new(x2, 0.0, 0.0)));
+        e.common_mut().extended_data.add_record(pipe_xdata(1.5, 0.013, Handle::new(from), Handle::new(to)));
+        e
+    }
+
+    #[test]
+    fn reconstructs_network_from_tagged_entities() {
+        let ents = vec![
+            structure(1, NodeKind::Inlet, 0.0, 104.0),
+            structure(2, NodeKind::Outfall, 100.0, 100.0),
+            pipe(1, 2, 0.0, 100.0),
+        ];
+        let net = network_from_entities(ents.iter()).unwrap();
+        assert_eq!(net.nodes.len(), 2);
+        assert_eq!(net.pipes.len(), 1);
+        assert_eq!(net.pipes[0].from, "N1");
+        assert_eq!(net.pipes[0].to, "N2");
+        assert!((net.pipes[0].length - 100.0).abs() < 1e-6);
+        assert!((net.pipes[0].diameter - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn errors_when_no_structures() {
+        let ents: Vec<EntityType> = vec![];
+        assert!(network_from_entities(ents.iter()).is_err());
+    }
+
+    #[test]
+    fn dangling_pipe_is_reported() {
+        let ents = vec![
+            structure(1, NodeKind::Inlet, 0.0, 104.0),
+            pipe(1, 99, 0.0, 100.0), // 99 doesn't exist
+        ];
+        assert!(network_from_entities(ents.iter()).is_err());
+    }
+}

--- a/src/modules/storm_sewer/icons/analyze.svg
+++ b/src/modules/storm_sewer/icons/analyze.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <path d="M6 38 q8 -14 16 0 t16 0 t16 0" fill="none" stroke="#4FC3F7" stroke-width="3"/>
+  <polygon points="24,16 24,32 40,24" fill="#01579B"/>
+</svg>

--- a/src/modules/storm_sewer/icons/inlet.svg
+++ b/src/modules/storm_sewer/icons/inlet.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="12" y="14" width="40" height="36" rx="3" fill="none" stroke="#01579B" stroke-width="3"/>
+  <line x1="12" y1="24" x2="52" y2="24" stroke="#0277BD" stroke-width="3"/>
+  <line x1="12" y1="32" x2="52" y2="32" stroke="#0277BD" stroke-width="3"/>
+  <line x1="12" y1="40" x2="52" y2="40" stroke="#0277BD" stroke-width="3"/>
+</svg>

--- a/src/modules/storm_sewer/icons/junction.svg
+++ b/src/modules/storm_sewer/icons/junction.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="18" fill="none" stroke="#01579B" stroke-width="3"/>
+  <circle cx="32" cy="32" r="8" fill="#4FC3F7"/>
+</svg>

--- a/src/modules/storm_sewer/icons/outfall.svg
+++ b/src/modules/storm_sewer/icons/outfall.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="10" y="24" width="24" height="16" fill="none" stroke="#01579B" stroke-width="3"/>
+  <path d="M34 22 L54 14 L54 50 L34 42 Z" fill="#4FC3F7" opacity="0.85" stroke="#0277BD" stroke-width="2"/>
+</svg>

--- a/src/modules/storm_sewer/icons/pipe.svg
+++ b/src/modules/storm_sewer/icons/pipe.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <line x1="12" y1="42" x2="52" y2="18" stroke="#01579B" stroke-width="4"/>
+  <line x1="16" y1="48" x2="56" y2="24" stroke="#4FC3F7" stroke-width="4"/>
+  <circle cx="13" cy="45" r="5" fill="none" stroke="#01579B" stroke-width="3"/>
+  <circle cx="55" cy="21" r="5" fill="none" stroke="#01579B" stroke-width="3"/>
+</svg>

--- a/src/modules/storm_sewer/icons/profile.svg
+++ b/src/modules/storm_sewer/icons/profile.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <polyline points="8,16 24,20 40,30 56,40" fill="none" stroke="#8D6E63" stroke-width="2"/>
+  <polyline points="8,46 24,47 40,49 56,50" fill="none" stroke="#01579B" stroke-width="3"/>
+  <polyline points="8,34 24,37 40,42 56,47" fill="none" stroke="#4FC3F7" stroke-width="2" stroke-dasharray="4 2"/>
+</svg>

--- a/src/modules/storm_sewer/icons/report.svg
+++ b/src/modules/storm_sewer/icons/report.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="16" y="10" width="32" height="44" rx="2" fill="none" stroke="#01579B" stroke-width="3"/>
+  <line x1="22" y1="20" x2="42" y2="20" stroke="#0277BD" stroke-width="2"/>
+  <line x1="22" y1="28" x2="42" y2="28" stroke="#0277BD" stroke-width="2"/>
+  <line x1="22" y1="36" x2="42" y2="36" stroke="#0277BD" stroke-width="2"/>
+  <line x1="22" y1="44" x2="36" y2="44" stroke="#0277BD" stroke-width="2"/>
+</svg>

--- a/src/modules/storm_sewer/mod.rs
+++ b/src/modules/storm_sewer/mod.rs
@@ -7,6 +7,7 @@
 // INTEGRATION.md for where each `SS_*` command plugs in.
 
 pub mod analysis;
+pub mod data;
 pub mod structures;
 
 use crate::modules::{CadModule, IconKind, ModuleEvent, RibbonGroup, RibbonItem, ToolDef};
@@ -155,5 +156,39 @@ PIPE P2 N2 OUT 300 1.5 0.013
     fn bad_ssn_reports_error() {
         let err = super::analysis::analyze_text("NODE X inlet 0 0 oops 1 1 1").unwrap_err();
         assert!(err.contains("line 1"), "{err}");
+    }
+
+    #[test]
+    fn analyze_doc_runs_on_drawn_network() {
+        use acadrust::types::Vector3;
+        use acadrust::{Circle, EntityType, Handle, Line};
+        use stormsewer::network::NodeKind;
+
+        let mk_struct = |h: u64, kind, x: f64, inv: f64| {
+            let mut e = EntityType::Circle(Circle {
+                center: Vector3::new(x, 0.0, 0.0),
+                radius: 3.0,
+                ..Default::default()
+            });
+            e.common_mut().handle = Handle::new(h);
+            e.common_mut()
+                .extended_data
+                .add_record(super::data::structure_xdata(kind, inv, inv + 6.0, 1.0, 0.7));
+            e
+        };
+        let mut pipe =
+            EntityType::Line(Line::from_points(Vector3::new(0.0, 0.0, 0.0), Vector3::new(200.0, 0.0, 0.0)));
+        pipe.common_mut()
+            .extended_data
+            .add_record(super::data::pipe_xdata(1.5, 0.013, Handle::new(1), Handle::new(2)));
+        let ents = vec![
+            mk_struct(1, NodeKind::Inlet, 0.0, 104.0),
+            mk_struct(2, NodeKind::Outfall, 200.0, 100.0),
+            pipe,
+        ];
+
+        let (annotations, report) = super::analysis::analyze_doc(ents.iter()).expect("analyze drawn net");
+        assert!(!annotations.is_empty(), "expected flow/HGL labels");
+        assert!(report.contains("STORM SEWER ANALYSIS"), "report:\n{report}");
     }
 }

--- a/src/modules/storm_sewer/mod.rs
+++ b/src/modules/storm_sewer/mod.rs
@@ -1,0 +1,159 @@
+// Storm Sewer module — gravity storm-drain network design & analysis.
+//
+// Implements the standard public-domain methods (Rational method, Manning,
+// HGL backwater) via the external `stormsewer` engine crate. The ribbon tab
+// here is the UI surface; the actual command handlers (place structure, draw
+// pipe, run analysis) are dispatched by the host command system — see
+// INTEGRATION.md for where each `SS_*` command plugs in.
+
+pub mod analysis;
+pub mod structures;
+
+use crate::modules::{CadModule, IconKind, ModuleEvent, RibbonGroup, RibbonItem, ToolDef};
+
+pub struct StormSewerModule;
+
+// Register the SS_* command names for command-line autocomplete.
+inventory::submit!(crate::command::CommandRegistration {
+    names: &[
+        "SS_INLET",
+        "SS_JUNCTION",
+        "SS_OUTFALL",
+        "SS_PIPE",
+        "SS_ANALYZE",
+        "SS_REPORT",
+        "SS_PROFILE",
+    ]
+});
+
+const IC_INLET: &[u8] = include_bytes!("icons/inlet.svg");
+const IC_JUNCTION: &[u8] = include_bytes!("icons/junction.svg");
+const IC_OUTFALL: &[u8] = include_bytes!("icons/outfall.svg");
+const IC_PIPE: &[u8] = include_bytes!("icons/pipe.svg");
+const IC_ANALYZE: &[u8] = include_bytes!("icons/analyze.svg");
+const IC_REPORT: &[u8] = include_bytes!("icons/report.svg");
+const IC_PROFILE: &[u8] = include_bytes!("icons/profile.svg");
+
+/// Convenience: an SVG-icon tool that fires a named `SS_*` command.
+fn tool(id: &'static str, label: &'static str, icon: &'static [u8]) -> ToolDef {
+    ToolDef {
+        id,
+        label,
+        icon: IconKind::Svg(icon),
+        event: ModuleEvent::Command(id.to_string()),
+    }
+}
+
+impl CadModule for StormSewerModule {
+    fn id(&self) -> &'static str {
+        "storm_sewer"
+    }
+    fn title(&self) -> &'static str {
+        "Storm Sewer"
+    }
+
+    fn ribbon_groups(&self) -> Vec<RibbonGroup> {
+        vec![
+            // ── Network: place structures and connect them with pipes ───────
+            RibbonGroup {
+                title: "Network",
+                tools: vec![
+                    RibbonItem::LargeTool(tool("SS_INLET", "Inlet", IC_INLET)),
+                    RibbonItem::LargeTool(tool("SS_JUNCTION", "Junction", IC_JUNCTION)),
+                    RibbonItem::LargeTool(tool("SS_OUTFALL", "Outfall", IC_OUTFALL)),
+                    RibbonItem::LargeTool(tool("SS_PIPE", "Pipe\nRun", IC_PIPE)),
+                ],
+            },
+            // ── Analysis: run the engine and review results ─────────────────
+            RibbonGroup {
+                title: "Analysis",
+                tools: vec![
+                    RibbonItem::LargeTool(tool("SS_ANALYZE", "Analyze", IC_ANALYZE)),
+                    RibbonItem::Tool(tool("SS_REPORT", "Report", IC_REPORT)),
+                    RibbonItem::Tool(tool("SS_PROFILE", "Profile", IC_PROFILE)),
+                ],
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::registry;
+
+    #[test]
+    fn module_is_registered_in_ribbon() {
+        let titles: Vec<&str> = registry::all_modules().iter().map(|m| m.title()).collect();
+        assert!(titles.contains(&"Storm Sewer"), "ribbon tabs: {titles:?}");
+    }
+
+    #[test]
+    fn ribbon_exposes_core_tools() {
+        let mut ids = Vec::new();
+        for g in StormSewerModule.ribbon_groups() {
+            for item in g.tools {
+                if let RibbonItem::Tool(t) | RibbonItem::LargeTool(t) = item {
+                    ids.push(t.id);
+                }
+            }
+        }
+        for needed in ["SS_INLET", "SS_PIPE", "SS_ANALYZE", "SS_REPORT", "SS_PROFILE"] {
+            assert!(ids.contains(&needed), "missing {needed}; have {ids:?}");
+        }
+    }
+
+    #[test]
+    fn engine_bridge_runs_inside_ocs() {
+        // The stormsewer crate, called from within the OCS binary, produces a
+        // full analysis report for the properly-sized sample network.
+        let report = super::analysis::demo_report();
+        assert!(report.contains("STORM SEWER ANALYSIS"), "no header:\n{report}");
+        assert!(report.contains("P1") && report.contains("HGL"), "no pipe/HGL:\n{report}");
+        assert!(report.contains("no surface flooding"), "expected ok design:\n{report}");
+    }
+
+    #[test]
+    fn analyze_plan_emits_entities_and_report() {
+        let (ents, report) = super::analysis::analyze_plan().expect("analysis runs");
+        // 3 pipes + 4 structures + labels  → comfortably more than 7 entities.
+        assert!(ents.len() >= 7, "too few entities: {}", ents.len());
+        assert!(report.contains("STORM SEWER ANALYSIS"));
+    }
+
+    #[test]
+    fn analyze_profile_emits_entities() {
+        let ents = super::analysis::analyze_profile().expect("profile runs");
+        // Ground + invert + HGL line segments along a 4-node stem.
+        assert!(ents.len() >= 6, "too few profile entities: {}", ents.len());
+    }
+
+    const SAMPLE_SSN: &str = "\
+IDF 60 10 0.8
+TAILWATER 100.5
+NODE N1 inlet 0 0 104 110 1 0.7 12
+NODE N2 inlet 300 0 102.5 108.5 1 0.7
+NODE OUT outfall 600 0 100 106
+PIPE P1 N1 N2 300 1.25 0.013
+PIPE P2 N2 OUT 300 1.5 0.013
+";
+
+    #[test]
+    fn analyze_text_parses_and_emits() {
+        let (ents, report) = super::analysis::analyze_text(SAMPLE_SSN).expect("parse + analyze");
+        assert!(ents.len() >= 5, "too few entities: {}", ents.len());
+        assert!(report.contains("STORM SEWER ANALYSIS"));
+    }
+
+    #[test]
+    fn profile_text_parses_and_emits() {
+        let ents = super::analysis::profile_text(SAMPLE_SSN).expect("parse + profile");
+        assert!(ents.len() >= 4, "too few profile entities: {}", ents.len());
+    }
+
+    #[test]
+    fn bad_ssn_reports_error() {
+        let err = super::analysis::analyze_text("NODE X inlet 0 0 oops 1 1 1").unwrap_err();
+        assert!(err.contains("line 1"), "{err}");
+    }
+}

--- a/src/modules/storm_sewer/structures.rs
+++ b/src/modules/storm_sewer/structures.rs
@@ -1,12 +1,12 @@
 // Interactive storm-sewer drafting commands.
 //
-// Both commands collect typed values FIRST (the command line stays focused),
-// then take the viewport interaction LAST and commit from it. This mirrors the
-// OFFSET command's flow and avoids losing command-line focus after a click
-// (which would otherwise route Enter to on_enter and cancel the command).
+// Robust placement: a canvas click ALWAYS places a structure (with the values
+// typed so far, defaults for the rest), so dropping a structure works even if
+// command-line text entry is unavailable. If typed entry works, enter
+// invert/rim/area/C first and then click — the click uses those values.
 //
-// PlaceStructure: enter invert/rim/area/C, then click the location.
-// PlacePipe: enter diameter/n, then click the START and END structures.
+// Pipes are pick-first: click the START structure then the END structure; the
+// pipe commits on the second click with the current diameter/n.
 
 use acadrust::types::Vector3;
 use acadrust::{Circle, EntityType, Handle, Line};
@@ -28,7 +28,7 @@ enum SStep {
     Rim,
     Area,
     C,
-    Point,
+    Ready,
 }
 
 pub struct PlaceStructure {
@@ -71,15 +71,15 @@ impl CadCommand for PlaceStructure {
     }
     fn prompt(&self) -> String {
         match self.step {
-            SStep::Invert => format!("Invert elevation <{:.2}>:", self.invert),
-            SStep::Rim => format!("Rim elevation <{:.2}>:", self.rim),
-            SStep::Area => format!("Drainage area, ac <{:.2}>:", self.area),
-            SStep::C => format!("Runoff coefficient C <{:.2}>:", self.c),
-            SStep::Point => format!("Storm {}: pick location:", data::kind_str(self.kind)),
+            SStep::Invert => format!("Storm {}: invert <{:.2}> (or click to place):", data::kind_str(self.kind), self.invert),
+            SStep::Rim => format!("Rim <{:.2}> (or click to place):", self.rim),
+            SStep::Area => format!("Drainage area, ac <{:.2}> (or click to place):", self.area),
+            SStep::C => format!("Runoff C <{:.2}> (or click to place):", self.c),
+            SStep::Ready => "Click to place the structure:".into(),
         }
     }
     fn wants_text_input(&self) -> bool {
-        !matches!(self.step, SStep::Point)
+        !matches!(self.step, SStep::Ready)
     }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
         let v = parse_num(text);
@@ -94,7 +94,7 @@ impl CadCommand for PlaceStructure {
                 if let Some(x) = v {
                     self.rim = x;
                 }
-                self.step = if self.kind == NodeKind::Outfall { SStep::Point } else { SStep::Area };
+                self.step = if self.kind == NodeKind::Outfall { SStep::Ready } else { SStep::Area };
             }
             SStep::Area => {
                 if let Some(x) = v {
@@ -106,31 +106,25 @@ impl CadCommand for PlaceStructure {
                 if let Some(x) = v {
                     self.c = x;
                 }
-                self.step = SStep::Point;
+                self.step = SStep::Ready;
             }
-            SStep::Point => {}
+            SStep::Ready => {}
         }
-        None // never commit from text; the location click commits
+        None
     }
     fn on_point(&mut self, pt: Vec3) -> CmdResult {
-        if let SStep::Point = self.step {
-            self.commit(pt.x as f64, pt.y as f64)
-        } else {
-            CmdResult::NeedPoint
-        }
+        // A click always places the structure, using whatever values have been
+        // entered (remaining fields keep their defaults).
+        self.commit(pt.x as f64, pt.y as f64)
     }
     fn on_enter(&mut self) -> CmdResult {
-        // Only reached at the Point step (text steps route empty Enter to
-        // on_text_input). Keep waiting for the click rather than cancelling.
         CmdResult::NeedPoint
     }
 }
 
-// ── Pipe placement ──────────────────────────────────────────────────────────
+// ── Pipe placement (pick-first, so clicks always work) ──────────────────────
 
 enum PStep {
-    Diameter,
-    N,
     PickStart,
     PickEnd,
 }
@@ -145,7 +139,7 @@ pub struct PlacePipe {
 
 impl PlacePipe {
     pub fn new() -> Self {
-        Self { step: PStep::Diameter, diameter: 1.25, n: 0.013, start_handle: None, start_xy: (0.0, 0.0) }
+        Self { step: PStep::PickStart, diameter: 1.25, n: 0.013, start_handle: None, start_xy: (0.0, 0.0) }
     }
     fn commit(&self, end_handle: Handle, ex: f64, ey: f64) -> CmdResult {
         let line = Line::from_points(
@@ -171,36 +165,12 @@ impl CadCommand for PlacePipe {
     }
     fn prompt(&self) -> String {
         match self.step {
-            PStep::Diameter => format!("Pipe diameter, ft <{:.2}>:", self.diameter),
-            PStep::N => format!("Manning n <{:.3}>:", self.n),
-            PStep::PickStart => "Pipe: pick START structure:".into(),
-            PStep::PickEnd => "Pipe: pick END structure:".into(),
+            PStep::PickStart => "Pipe: click the START structure:".into(),
+            PStep::PickEnd => format!("Pipe: click the END structure (dia {:.2} ft, n {:.3}):", self.diameter, self.n),
         }
-    }
-    fn wants_text_input(&self) -> bool {
-        matches!(self.step, PStep::Diameter | PStep::N)
-    }
-    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
-        let v = parse_num(text);
-        match self.step {
-            PStep::Diameter => {
-                if let Some(x) = v {
-                    self.diameter = x;
-                }
-                self.step = PStep::N;
-            }
-            PStep::N => {
-                if let Some(x) = v {
-                    self.n = x;
-                }
-                self.step = PStep::PickStart;
-            }
-            _ => {}
-        }
-        None
     }
     fn needs_entity_pick(&self) -> bool {
-        matches!(self.step, PStep::PickStart | PStep::PickEnd)
+        true
     }
     fn on_entity_pick(&mut self, handle: Handle, pt: Vec3) -> CmdResult {
         match self.step {
@@ -211,7 +181,6 @@ impl CadCommand for PlacePipe {
                 CmdResult::NeedPoint
             }
             PStep::PickEnd => self.commit(handle, pt.x as f64, pt.y as f64),
-            _ => CmdResult::NeedPoint,
         }
     }
     fn on_point(&mut self, _pt: Vec3) -> CmdResult {
@@ -227,43 +196,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn structure_prompts_then_commits_tagged_circle_on_click() {
+    fn click_places_structure_with_defaults() {
+        // A click commits immediately (no typed values needed).
         let mut cmd = PlaceStructure::inlet();
-        assert!(cmd.wants_text_input(), "should start by asking for invert");
-        assert!(cmd.on_text_input("104").is_none()); // invert -> rim
-        assert!(cmd.on_text_input("110").is_none()); // rim -> area
-        assert!(cmd.on_text_input("2.0").is_none()); // area -> C
-        assert!(cmd.on_text_input("0.8").is_none()); // C -> Point
-        assert!(!cmd.wants_text_input(), "should now wait for the location click");
         match cmd.on_point(Vec3::new(10.0, 20.0, 0.0)) {
             CmdResult::CommitAndExit(EntityType::Circle(c)) => {
                 assert_eq!(c.center.x, 10.0);
                 let e = EntityType::Circle(c);
                 assert!(e.common().extended_data.get_record(data::APP_STRUCT).is_some());
             }
-            _ => panic!("expected CommitAndExit(Circle) with XDATA"),
+            _ => panic!("expected CommitAndExit(Circle)"),
         }
     }
 
     #[test]
-    fn outfall_skips_area_and_c() {
-        let mut cmd = PlaceStructure::outfall();
-        assert!(cmd.on_text_input("100").is_none()); // invert -> rim
-        assert!(cmd.on_text_input("105").is_none()); // rim -> Point (no area/C)
-        assert!(!cmd.wants_text_input());
+    fn typed_values_are_captured_then_click_places() {
+        let mut cmd = PlaceStructure::inlet();
+        assert!(cmd.on_text_input("104").is_none()); // invert -> rim
+        assert!(cmd.on_text_input("110").is_none()); // rim -> area
+        assert!(cmd.on_text_input("2.0").is_none()); // area -> C
+        assert!(cmd.on_text_input("0.8").is_none()); // C -> Ready
+        assert!(matches!(cmd.step, SStep::Ready));
         assert!(matches!(cmd.on_point(Vec3::ZERO), CmdResult::CommitAndExit(_)));
     }
 
     #[test]
-    fn pipe_enters_size_then_connects_two_structures() {
+    fn pipe_connects_two_structures_on_two_clicks() {
         let mut cmd = PlacePipe::new();
-        assert!(cmd.wants_text_input(), "should ask diameter first");
-        assert!(cmd.on_text_input("1.5").is_none()); // diameter -> n
-        assert!(cmd.on_text_input("0.013").is_none()); // n -> PickStart
-        assert!(cmd.needs_entity_pick(), "now picking structures");
-        // pick start at (0,0)
+        assert!(cmd.needs_entity_pick());
         assert!(matches!(cmd.on_entity_pick(Handle::new(1), Vec3::new(0.0, 0.0, 0.0)), CmdResult::NeedPoint));
-        // pick end at (100,0) -> commits a line carrying connectivity XDATA
         match cmd.on_entity_pick(Handle::new(2), Vec3::new(100.0, 0.0, 0.0)) {
             CmdResult::CommitAndExit(EntityType::Line(l)) => {
                 assert_eq!(l.start.x, 0.0);
@@ -271,7 +232,7 @@ mod tests {
                 let e = EntityType::Line(l);
                 assert!(e.common().extended_data.get_record(data::APP_PIPE).is_some());
             }
-            _ => panic!("expected CommitAndExit(Line) with XDATA"),
+            _ => panic!("expected CommitAndExit(Line)"),
         }
     }
 }

--- a/src/modules/storm_sewer/structures.rs
+++ b/src/modules/storm_sewer/structures.rs
@@ -1,9 +1,12 @@
 // Interactive storm-sewer drafting commands.
 //
-// PlaceStructure: pick a location, then prompt invert/rim/area/C on the command
-// line; commits a circle marker carrying StormSewer XDATA.
-// PlacePipe: pick a start structure and an end structure (snaps to their
-// centers), prompt diameter/n; commits a line carrying XDATA with connectivity.
+// Both commands collect typed values FIRST (the command line stays focused),
+// then take the viewport interaction LAST and commit from it. This mirrors the
+// OFFSET command's flow and avoids losing command-line focus after a click
+// (which would otherwise route Enter to on_enter and cancel the command).
+//
+// PlaceStructure: enter invert/rim/area/C, then click the location.
+// PlacePipe: enter diameter/n, then click the START and END structures.
 
 use acadrust::types::Vector3;
 use acadrust::{Circle, EntityType, Handle, Line};
@@ -21,18 +24,16 @@ fn parse_num(text: &str) -> Option<f64> {
 // ── Structure placement ─────────────────────────────────────────────────────
 
 enum SStep {
-    Point,
     Invert,
     Rim,
     Area,
     C,
+    Point,
 }
 
 pub struct PlaceStructure {
     kind: NodeKind,
     radius: f64,
-    x: f64,
-    y: f64,
     invert: f64,
     rim: f64,
     area: f64,
@@ -51,10 +52,10 @@ impl PlaceStructure {
         Self::new(NodeKind::Outfall, 6.0)
     }
     fn new(kind: NodeKind, radius: f64) -> Self {
-        Self { kind, radius, x: 0.0, y: 0.0, invert: 100.0, rim: 105.0, area: 1.0, c: 0.70, step: SStep::Point }
+        Self { kind, radius, invert: 100.0, rim: 105.0, area: 1.0, c: 0.70, step: SStep::Invert }
     }
-    fn commit(&self) -> CmdResult {
-        let circ = Circle { center: Vector3::new(self.x, self.y, 0.0), radius: self.radius, ..Default::default() };
+    fn commit(&self, x: f64, y: f64) -> CmdResult {
+        let circ = Circle { center: Vector3::new(x, y, 0.0), radius: self.radius, ..Default::default() };
         let mut ent = EntityType::Circle(circ);
         let (area, c) = if self.kind == NodeKind::Outfall { (0.0, 0.0) } else { (self.area, self.c) };
         ent.common_mut()
@@ -70,20 +71,12 @@ impl CadCommand for PlaceStructure {
     }
     fn prompt(&self) -> String {
         match self.step {
-            SStep::Point => format!("Storm {}: pick location:", data::kind_str(self.kind)),
             SStep::Invert => format!("Invert elevation <{:.2}>:", self.invert),
             SStep::Rim => format!("Rim elevation <{:.2}>:", self.rim),
             SStep::Area => format!("Drainage area, ac <{:.2}>:", self.area),
             SStep::C => format!("Runoff coefficient C <{:.2}>:", self.c),
+            SStep::Point => format!("Storm {}: pick location:", data::kind_str(self.kind)),
         }
-    }
-    fn on_point(&mut self, pt: Vec3) -> CmdResult {
-        if let SStep::Point = self.step {
-            self.x = pt.x as f64;
-            self.y = pt.y as f64;
-            self.step = SStep::Invert;
-        }
-        CmdResult::NeedPoint
     }
     fn wants_text_input(&self) -> bool {
         !matches!(self.step, SStep::Point)
@@ -91,87 +84,77 @@ impl CadCommand for PlaceStructure {
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
         let v = parse_num(text);
         match self.step {
-            SStep::Point => None,
             SStep::Invert => {
                 if let Some(x) = v {
                     self.invert = x;
                 }
                 self.step = SStep::Rim;
-                None
             }
             SStep::Rim => {
                 if let Some(x) = v {
                     self.rim = x;
                 }
-                if self.kind == NodeKind::Outfall {
-                    Some(self.commit())
-                } else {
-                    self.step = SStep::Area;
-                    None
-                }
+                self.step = if self.kind == NodeKind::Outfall { SStep::Point } else { SStep::Area };
             }
             SStep::Area => {
                 if let Some(x) = v {
                     self.area = x;
                 }
                 self.step = SStep::C;
-                None
             }
             SStep::C => {
                 if let Some(x) = v {
                     self.c = x;
                 }
-                Some(self.commit())
+                self.step = SStep::Point;
             }
+            SStep::Point => {}
+        }
+        None // never commit from text; the location click commits
+    }
+    fn on_point(&mut self, pt: Vec3) -> CmdResult {
+        if let SStep::Point = self.step {
+            self.commit(pt.x as f64, pt.y as f64)
+        } else {
+            CmdResult::NeedPoint
         }
     }
     fn on_enter(&mut self) -> CmdResult {
-        CmdResult::Cancel
+        // Only reached at the Point step (text steps route empty Enter to
+        // on_text_input). Keep waiting for the click rather than cancelling.
+        CmdResult::NeedPoint
     }
 }
 
 // ── Pipe placement ──────────────────────────────────────────────────────────
 
 enum PStep {
-    PickStart,
-    PickEnd,
     Diameter,
     N,
+    PickStart,
+    PickEnd,
 }
 
 pub struct PlacePipe {
     step: PStep,
-    start_handle: Option<Handle>,
-    start_xy: (f64, f64),
-    end_handle: Option<Handle>,
-    end_xy: (f64, f64),
-    pending: Option<Handle>,
     diameter: f64,
     n: f64,
+    start_handle: Option<Handle>,
+    start_xy: (f64, f64),
 }
 
 impl PlacePipe {
     pub fn new() -> Self {
-        Self {
-            step: PStep::PickStart,
-            start_handle: None,
-            start_xy: (0.0, 0.0),
-            end_handle: None,
-            end_xy: (0.0, 0.0),
-            pending: None,
-            diameter: 1.25,
-            n: 0.013,
-        }
+        Self { step: PStep::Diameter, diameter: 1.25, n: 0.013, start_handle: None, start_xy: (0.0, 0.0) }
     }
-    fn commit(&self) -> CmdResult {
+    fn commit(&self, end_handle: Handle, ex: f64, ey: f64) -> CmdResult {
         let line = Line::from_points(
             Vector3::new(self.start_xy.0, self.start_xy.1, 0.0),
-            Vector3::new(self.end_xy.0, self.end_xy.1, 0.0),
+            Vector3::new(ex, ey, 0.0),
         );
         let mut ent = EntityType::Line(line);
-        if let (Some(f), Some(t)) = (self.start_handle, self.end_handle) {
-            ent.common_mut().extended_data.add_record(data::pipe_xdata(self.diameter, self.n, f, t));
-        }
+        let from = self.start_handle.unwrap_or(Handle::new(0));
+        ent.common_mut().extended_data.add_record(data::pipe_xdata(self.diameter, self.n, from, end_handle));
         CmdResult::CommitAndExit(ent)
     }
 }
@@ -188,43 +171,10 @@ impl CadCommand for PlacePipe {
     }
     fn prompt(&self) -> String {
         match self.step {
-            PStep::PickStart => "Pipe: pick START structure:".into(),
-            PStep::PickEnd => "Pipe: pick END structure:".into(),
             PStep::Diameter => format!("Pipe diameter, ft <{:.2}>:", self.diameter),
             PStep::N => format!("Manning n <{:.3}>:", self.n),
-        }
-    }
-    fn needs_entity_pick(&self) -> bool {
-        matches!(self.step, PStep::PickStart | PStep::PickEnd)
-    }
-    fn on_entity_pick(&mut self, handle: Handle, _pt: Vec3) -> CmdResult {
-        // Stash the handle; inject_picked_entity validates it and reads center.
-        self.pending = Some(handle);
-        CmdResult::NeedPoint
-    }
-    fn inject_picked_entity(&mut self, entity: EntityType) {
-        let is_struct = entity.common().extended_data.get_record(data::APP_STRUCT).is_some();
-        let center = match &entity {
-            EntityType::Circle(c) => Some((c.center.x, c.center.y)),
-            _ => None,
-        };
-        if !is_struct || center.is_none() {
-            self.pending = None;
-            return;
-        }
-        let center = center.unwrap();
-        match self.step {
-            PStep::PickStart => {
-                self.start_handle = self.pending.take();
-                self.start_xy = center;
-                self.step = PStep::PickEnd;
-            }
-            PStep::PickEnd => {
-                self.end_handle = self.pending.take();
-                self.end_xy = center;
-                self.step = PStep::Diameter;
-            }
-            _ => {}
+            PStep::PickStart => "Pipe: pick START structure:".into(),
+            PStep::PickEnd => "Pipe: pick END structure:".into(),
         }
     }
     fn wants_text_input(&self) -> bool {
@@ -238,22 +188,37 @@ impl CadCommand for PlacePipe {
                     self.diameter = x;
                 }
                 self.step = PStep::N;
-                None
             }
             PStep::N => {
                 if let Some(x) = v {
                     self.n = x;
                 }
-                Some(self.commit())
+                self.step = PStep::PickStart;
             }
-            _ => None,
+            _ => {}
+        }
+        None
+    }
+    fn needs_entity_pick(&self) -> bool {
+        matches!(self.step, PStep::PickStart | PStep::PickEnd)
+    }
+    fn on_entity_pick(&mut self, handle: Handle, pt: Vec3) -> CmdResult {
+        match self.step {
+            PStep::PickStart => {
+                self.start_handle = Some(handle);
+                self.start_xy = (pt.x as f64, pt.y as f64);
+                self.step = PStep::PickEnd;
+                CmdResult::NeedPoint
+            }
+            PStep::PickEnd => self.commit(handle, pt.x as f64, pt.y as f64),
+            _ => CmdResult::NeedPoint,
         }
     }
     fn on_point(&mut self, _pt: Vec3) -> CmdResult {
         CmdResult::NeedPoint
     }
     fn on_enter(&mut self) -> CmdResult {
-        CmdResult::Cancel
+        CmdResult::NeedPoint
     }
 }
 
@@ -262,20 +227,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn structure_prompts_then_commits_tagged_circle() {
+    fn structure_prompts_then_commits_tagged_circle_on_click() {
         let mut cmd = PlaceStructure::inlet();
-        // pick a point
-        assert!(matches!(cmd.on_point(Vec3::new(10.0, 20.0, 0.0)), CmdResult::NeedPoint));
-        assert!(cmd.wants_text_input());
-        // invert, rim, area, then C completes
+        assert!(cmd.wants_text_input(), "should start by asking for invert");
         assert!(cmd.on_text_input("104").is_none()); // invert -> rim
         assert!(cmd.on_text_input("110").is_none()); // rim -> area
         assert!(cmd.on_text_input("2.0").is_none()); // area -> C
-        match cmd.on_text_input("0.8") {
-            Some(CmdResult::CommitAndExit(EntityType::Circle(c))) => {
+        assert!(cmd.on_text_input("0.8").is_none()); // C -> Point
+        assert!(!cmd.wants_text_input(), "should now wait for the location click");
+        match cmd.on_point(Vec3::new(10.0, 20.0, 0.0)) {
+            CmdResult::CommitAndExit(EntityType::Circle(c)) => {
                 assert_eq!(c.center.x, 10.0);
-                let rec = EntityType::Circle(c.clone());
-                assert!(rec.common().extended_data.get_record(data::APP_STRUCT).is_some());
+                let e = EntityType::Circle(c);
+                assert!(e.common().extended_data.get_record(data::APP_STRUCT).is_some());
             }
             _ => panic!("expected CommitAndExit(Circle) with XDATA"),
         }
@@ -284,34 +248,30 @@ mod tests {
     #[test]
     fn outfall_skips_area_and_c() {
         let mut cmd = PlaceStructure::outfall();
-        cmd.on_point(Vec3::new(0.0, 0.0, 0.0));
         assert!(cmd.on_text_input("100").is_none()); // invert -> rim
-        // rim completes immediately for an outfall
-        assert!(matches!(cmd.on_text_input("105"), Some(CmdResult::CommitAndExit(_))));
+        assert!(cmd.on_text_input("105").is_none()); // rim -> Point (no area/C)
+        assert!(!cmd.wants_text_input());
+        assert!(matches!(cmd.on_point(Vec3::ZERO), CmdResult::CommitAndExit(_)));
     }
 
     #[test]
-    fn pipe_connects_two_structures() {
+    fn pipe_enters_size_then_connects_two_structures() {
         let mut cmd = PlacePipe::new();
-        assert!(cmd.needs_entity_pick());
-        // simulate picking the start structure
-        let mut s1 = EntityType::Circle(Circle { center: Vector3::new(0.0, 0.0, 0.0), radius: 3.0, ..Default::default() });
-        s1.common_mut().extended_data.add_record(data::structure_xdata(NodeKind::Inlet, 100.0, 105.0, 1.0, 0.7));
-        cmd.on_entity_pick(Handle::default(), Vec3::ZERO);
-        cmd.inject_picked_entity(s1);
-        // now picking the end structure
-        let mut s2 = EntityType::Circle(Circle { center: Vector3::new(100.0, 0.0, 0.0), radius: 3.0, ..Default::default() });
-        s2.common_mut().extended_data.add_record(data::structure_xdata(NodeKind::Outfall, 99.0, 104.0, 0.0, 0.0));
-        cmd.on_entity_pick(Handle::default(), Vec3::ZERO);
-        cmd.inject_picked_entity(s2);
-        assert!(cmd.wants_text_input(), "should be prompting diameter");
+        assert!(cmd.wants_text_input(), "should ask diameter first");
         assert!(cmd.on_text_input("1.5").is_none()); // diameter -> n
-        match cmd.on_text_input("0.013") {
-            Some(CmdResult::CommitAndExit(EntityType::Line(l))) => {
+        assert!(cmd.on_text_input("0.013").is_none()); // n -> PickStart
+        assert!(cmd.needs_entity_pick(), "now picking structures");
+        // pick start at (0,0)
+        assert!(matches!(cmd.on_entity_pick(Handle::new(1), Vec3::new(0.0, 0.0, 0.0)), CmdResult::NeedPoint));
+        // pick end at (100,0) -> commits a line carrying connectivity XDATA
+        match cmd.on_entity_pick(Handle::new(2), Vec3::new(100.0, 0.0, 0.0)) {
+            CmdResult::CommitAndExit(EntityType::Line(l)) => {
                 assert_eq!(l.start.x, 0.0);
                 assert_eq!(l.end.x, 100.0);
+                let e = EntityType::Line(l);
+                assert!(e.common().extended_data.get_record(data::APP_PIPE).is_some());
             }
-            _ => panic!("expected CommitAndExit(Line)"),
+            _ => panic!("expected CommitAndExit(Line) with XDATA"),
         }
     }
 }

--- a/src/modules/storm_sewer/structures.rs
+++ b/src/modules/storm_sewer/structures.rs
@@ -1,36 +1,66 @@
-// Interactive storm-sewer drafting commands: place structure markers and draw
-// pipe runs on the canvas.
+// Interactive storm-sewer drafting commands.
 //
-// These create geometry (circle markers, pipe lines). Attaching hydraulic data
-// (invert, rim, area, C, diameter) to placed structures — so SS_ANALYZE reads
-// the drawn network instead of the built-in sample — is the next step; see
-// INTEGRATION.md.
+// PlaceStructure: pick a location, then prompt invert/rim/area/C on the command
+// line; commits a circle marker carrying StormSewer XDATA.
+// PlacePipe: pick a start structure and an end structure (snaps to their
+// centers), prompt diameter/n; commits a line carrying XDATA with connectivity.
 
 use acadrust::types::Vector3;
-use acadrust::{Circle, EntityType, Line};
+use acadrust::{Circle, EntityType, Handle, Line};
 use glam::Vec3;
 
+use stormsewer::network::NodeKind;
+
+use super::data;
 use crate::command::{CadCommand, CmdResult};
 
-fn v3(p: Vec3) -> Vector3 {
-    Vector3::new(p.x as f64, p.y as f64, 0.0)
+fn parse_num(text: &str) -> Option<f64> {
+    text.trim().replace(',', ".").parse::<f64>().ok()
 }
 
-/// Repeatedly place a structure marker (a circle) at picked points.
+// ── Structure placement ─────────────────────────────────────────────────────
+
+enum SStep {
+    Point,
+    Invert,
+    Rim,
+    Area,
+    C,
+}
+
 pub struct PlaceStructure {
-    label: &'static str,
+    kind: NodeKind,
     radius: f64,
+    x: f64,
+    y: f64,
+    invert: f64,
+    rim: f64,
+    area: f64,
+    c: f64,
+    step: SStep,
 }
 
 impl PlaceStructure {
     pub fn inlet() -> Self {
-        Self { label: "inlet", radius: 3.0 }
+        Self::new(NodeKind::Inlet, 3.0)
     }
     pub fn junction() -> Self {
-        Self { label: "junction", radius: 4.0 }
+        Self::new(NodeKind::Junction, 4.0)
     }
     pub fn outfall() -> Self {
-        Self { label: "outfall", radius: 6.0 }
+        Self::new(NodeKind::Outfall, 6.0)
+    }
+    fn new(kind: NodeKind, radius: f64) -> Self {
+        Self { kind, radius, x: 0.0, y: 0.0, invert: 100.0, rim: 105.0, area: 1.0, c: 0.70, step: SStep::Point }
+    }
+    fn commit(&self) -> CmdResult {
+        let circ = Circle { center: Vector3::new(self.x, self.y, 0.0), radius: self.radius, ..Default::default() };
+        let mut ent = EntityType::Circle(circ);
+        let (area, c) = if self.kind == NodeKind::Outfall { (0.0, 0.0) } else { (self.area, self.c) };
+        ent.common_mut()
+            .extended_data
+            .add_record(data::structure_xdata(self.kind, self.invert, self.rim, area, c));
+        CmdResult::CommitAndExit(ent)
     }
 }
 
@@ -39,26 +69,110 @@ impl CadCommand for PlaceStructure {
         "SS_STRUCTURE"
     }
     fn prompt(&self) -> String {
-        format!("Storm sewer: pick {} location  [Esc = done]", self.label)
+        match self.step {
+            SStep::Point => format!("Storm {}: pick location:", data::kind_str(self.kind)),
+            SStep::Invert => format!("Invert elevation <{:.2}>:", self.invert),
+            SStep::Rim => format!("Rim elevation <{:.2}>:", self.rim),
+            SStep::Area => format!("Drainage area, ac <{:.2}>:", self.area),
+            SStep::C => format!("Runoff coefficient C <{:.2}>:", self.c),
+        }
     }
     fn on_point(&mut self, pt: Vec3) -> CmdResult {
-        let marker = Circle { center: v3(pt), radius: self.radius, ..Default::default() };
-        // CommitEntity keeps the command active so several can be dropped.
-        CmdResult::CommitEntity(EntityType::Circle(marker))
+        if let SStep::Point = self.step {
+            self.x = pt.x as f64;
+            self.y = pt.y as f64;
+            self.step = SStep::Invert;
+        }
+        CmdResult::NeedPoint
+    }
+    fn wants_text_input(&self) -> bool {
+        !matches!(self.step, SStep::Point)
+    }
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        let v = parse_num(text);
+        match self.step {
+            SStep::Point => None,
+            SStep::Invert => {
+                if let Some(x) = v {
+                    self.invert = x;
+                }
+                self.step = SStep::Rim;
+                None
+            }
+            SStep::Rim => {
+                if let Some(x) = v {
+                    self.rim = x;
+                }
+                if self.kind == NodeKind::Outfall {
+                    Some(self.commit())
+                } else {
+                    self.step = SStep::Area;
+                    None
+                }
+            }
+            SStep::Area => {
+                if let Some(x) = v {
+                    self.area = x;
+                }
+                self.step = SStep::C;
+                None
+            }
+            SStep::C => {
+                if let Some(x) = v {
+                    self.c = x;
+                }
+                Some(self.commit())
+            }
+        }
     }
     fn on_enter(&mut self) -> CmdResult {
         CmdResult::Cancel
     }
 }
 
-/// Draw pipe runs as connected line segments (chains like LINE).
+// ── Pipe placement ──────────────────────────────────────────────────────────
+
+enum PStep {
+    PickStart,
+    PickEnd,
+    Diameter,
+    N,
+}
+
 pub struct PlacePipe {
-    last: Option<Vec3>,
+    step: PStep,
+    start_handle: Option<Handle>,
+    start_xy: (f64, f64),
+    end_handle: Option<Handle>,
+    end_xy: (f64, f64),
+    pending: Option<Handle>,
+    diameter: f64,
+    n: f64,
 }
 
 impl PlacePipe {
     pub fn new() -> Self {
-        Self { last: None }
+        Self {
+            step: PStep::PickStart,
+            start_handle: None,
+            start_xy: (0.0, 0.0),
+            end_handle: None,
+            end_xy: (0.0, 0.0),
+            pending: None,
+            diameter: 1.25,
+            n: 0.013,
+        }
+    }
+    fn commit(&self) -> CmdResult {
+        let line = Line::from_points(
+            Vector3::new(self.start_xy.0, self.start_xy.1, 0.0),
+            Vector3::new(self.end_xy.0, self.end_xy.1, 0.0),
+        );
+        let mut ent = EntityType::Line(line);
+        if let (Some(f), Some(t)) = (self.start_handle, self.end_handle) {
+            ent.common_mut().extended_data.add_record(data::pipe_xdata(self.diameter, self.n, f, t));
+        }
+        CmdResult::CommitAndExit(ent)
     }
 }
 
@@ -73,24 +187,70 @@ impl CadCommand for PlacePipe {
         "SS_PIPE"
     }
     fn prompt(&self) -> String {
-        if self.last.is_none() {
-            "Storm sewer pipe: pick start structure".into()
-        } else {
-            "Storm sewer pipe: pick next structure  [Esc = done]".into()
+        match self.step {
+            PStep::PickStart => "Pipe: pick START structure:".into(),
+            PStep::PickEnd => "Pipe: pick END structure:".into(),
+            PStep::Diameter => format!("Pipe diameter, ft <{:.2}>:", self.diameter),
+            PStep::N => format!("Manning n <{:.3}>:", self.n),
         }
     }
-    fn on_point(&mut self, pt: Vec3) -> CmdResult {
-        match self.last {
-            None => {
-                self.last = Some(pt);
-                CmdResult::NeedPoint
-            }
-            Some(prev) => {
-                let pipe = Line::from_points(v3(prev), v3(pt));
-                self.last = Some(pt);
-                CmdResult::CommitEntity(EntityType::Line(pipe))
-            }
+    fn needs_entity_pick(&self) -> bool {
+        matches!(self.step, PStep::PickStart | PStep::PickEnd)
+    }
+    fn on_entity_pick(&mut self, handle: Handle, _pt: Vec3) -> CmdResult {
+        // Stash the handle; inject_picked_entity validates it and reads center.
+        self.pending = Some(handle);
+        CmdResult::NeedPoint
+    }
+    fn inject_picked_entity(&mut self, entity: EntityType) {
+        let is_struct = entity.common().extended_data.get_record(data::APP_STRUCT).is_some();
+        let center = match &entity {
+            EntityType::Circle(c) => Some((c.center.x, c.center.y)),
+            _ => None,
+        };
+        if !is_struct || center.is_none() {
+            self.pending = None;
+            return;
         }
+        let center = center.unwrap();
+        match self.step {
+            PStep::PickStart => {
+                self.start_handle = self.pending.take();
+                self.start_xy = center;
+                self.step = PStep::PickEnd;
+            }
+            PStep::PickEnd => {
+                self.end_handle = self.pending.take();
+                self.end_xy = center;
+                self.step = PStep::Diameter;
+            }
+            _ => {}
+        }
+    }
+    fn wants_text_input(&self) -> bool {
+        matches!(self.step, PStep::Diameter | PStep::N)
+    }
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        let v = parse_num(text);
+        match self.step {
+            PStep::Diameter => {
+                if let Some(x) = v {
+                    self.diameter = x;
+                }
+                self.step = PStep::N;
+                None
+            }
+            PStep::N => {
+                if let Some(x) = v {
+                    self.n = x;
+                }
+                Some(self.commit())
+            }
+            _ => None,
+        }
+    }
+    fn on_point(&mut self, _pt: Vec3) -> CmdResult {
+        CmdResult::NeedPoint
     }
     fn on_enter(&mut self) -> CmdResult {
         CmdResult::Cancel
@@ -102,28 +262,56 @@ mod tests {
     use super::*;
 
     #[test]
-    fn structure_commits_a_circle_and_stays_active() {
+    fn structure_prompts_then_commits_tagged_circle() {
         let mut cmd = PlaceStructure::inlet();
-        match cmd.on_point(Vec3::new(10.0, 20.0, 0.0)) {
-            CmdResult::CommitEntity(EntityType::Circle(c)) => {
+        // pick a point
+        assert!(matches!(cmd.on_point(Vec3::new(10.0, 20.0, 0.0)), CmdResult::NeedPoint));
+        assert!(cmd.wants_text_input());
+        // invert, rim, area, then C completes
+        assert!(cmd.on_text_input("104").is_none()); // invert -> rim
+        assert!(cmd.on_text_input("110").is_none()); // rim -> area
+        assert!(cmd.on_text_input("2.0").is_none()); // area -> C
+        match cmd.on_text_input("0.8") {
+            Some(CmdResult::CommitAndExit(EntityType::Circle(c))) => {
                 assert_eq!(c.center.x, 10.0);
-                assert_eq!(c.center.y, 20.0);
-                assert!(c.radius > 0.0);
+                let rec = EntityType::Circle(c.clone());
+                assert!(rec.common().extended_data.get_record(data::APP_STRUCT).is_some());
             }
-            _ => panic!("expected CommitEntity(Circle)"),
+            _ => panic!("expected CommitAndExit(Circle) with XDATA"),
         }
     }
 
     #[test]
-    fn pipe_needs_two_points_then_commits_a_line() {
+    fn outfall_skips_area_and_c() {
+        let mut cmd = PlaceStructure::outfall();
+        cmd.on_point(Vec3::new(0.0, 0.0, 0.0));
+        assert!(cmd.on_text_input("100").is_none()); // invert -> rim
+        // rim completes immediately for an outfall
+        assert!(matches!(cmd.on_text_input("105"), Some(CmdResult::CommitAndExit(_))));
+    }
+
+    #[test]
+    fn pipe_connects_two_structures() {
         let mut cmd = PlacePipe::new();
-        assert!(matches!(cmd.on_point(Vec3::new(0.0, 0.0, 0.0)), CmdResult::NeedPoint));
-        match cmd.on_point(Vec3::new(100.0, 0.0, 0.0)) {
-            CmdResult::CommitEntity(EntityType::Line(l)) => {
+        assert!(cmd.needs_entity_pick());
+        // simulate picking the start structure
+        let mut s1 = EntityType::Circle(Circle { center: Vector3::new(0.0, 0.0, 0.0), radius: 3.0, ..Default::default() });
+        s1.common_mut().extended_data.add_record(data::structure_xdata(NodeKind::Inlet, 100.0, 105.0, 1.0, 0.7));
+        cmd.on_entity_pick(Handle::default(), Vec3::ZERO);
+        cmd.inject_picked_entity(s1);
+        // now picking the end structure
+        let mut s2 = EntityType::Circle(Circle { center: Vector3::new(100.0, 0.0, 0.0), radius: 3.0, ..Default::default() });
+        s2.common_mut().extended_data.add_record(data::structure_xdata(NodeKind::Outfall, 99.0, 104.0, 0.0, 0.0));
+        cmd.on_entity_pick(Handle::default(), Vec3::ZERO);
+        cmd.inject_picked_entity(s2);
+        assert!(cmd.wants_text_input(), "should be prompting diameter");
+        assert!(cmd.on_text_input("1.5").is_none()); // diameter -> n
+        match cmd.on_text_input("0.013") {
+            Some(CmdResult::CommitAndExit(EntityType::Line(l))) => {
                 assert_eq!(l.start.x, 0.0);
                 assert_eq!(l.end.x, 100.0);
             }
-            _ => panic!("expected CommitEntity(Line)"),
+            _ => panic!("expected CommitAndExit(Line)"),
         }
     }
 }

--- a/src/modules/storm_sewer/structures.rs
+++ b/src/modules/storm_sewer/structures.rs
@@ -1,0 +1,129 @@
+// Interactive storm-sewer drafting commands: place structure markers and draw
+// pipe runs on the canvas.
+//
+// These create geometry (circle markers, pipe lines). Attaching hydraulic data
+// (invert, rim, area, C, diameter) to placed structures — so SS_ANALYZE reads
+// the drawn network instead of the built-in sample — is the next step; see
+// INTEGRATION.md.
+
+use acadrust::types::Vector3;
+use acadrust::{Circle, EntityType, Line};
+use glam::Vec3;
+
+use crate::command::{CadCommand, CmdResult};
+
+fn v3(p: Vec3) -> Vector3 {
+    Vector3::new(p.x as f64, p.y as f64, 0.0)
+}
+
+/// Repeatedly place a structure marker (a circle) at picked points.
+pub struct PlaceStructure {
+    label: &'static str,
+    radius: f64,
+}
+
+impl PlaceStructure {
+    pub fn inlet() -> Self {
+        Self { label: "inlet", radius: 3.0 }
+    }
+    pub fn junction() -> Self {
+        Self { label: "junction", radius: 4.0 }
+    }
+    pub fn outfall() -> Self {
+        Self { label: "outfall", radius: 6.0 }
+    }
+}
+
+impl CadCommand for PlaceStructure {
+    fn name(&self) -> &'static str {
+        "SS_STRUCTURE"
+    }
+    fn prompt(&self) -> String {
+        format!("Storm sewer: pick {} location  [Esc = done]", self.label)
+    }
+    fn on_point(&mut self, pt: Vec3) -> CmdResult {
+        let marker = Circle { center: v3(pt), radius: self.radius, ..Default::default() };
+        // CommitEntity keeps the command active so several can be dropped.
+        CmdResult::CommitEntity(EntityType::Circle(marker))
+    }
+    fn on_enter(&mut self) -> CmdResult {
+        CmdResult::Cancel
+    }
+}
+
+/// Draw pipe runs as connected line segments (chains like LINE).
+pub struct PlacePipe {
+    last: Option<Vec3>,
+}
+
+impl PlacePipe {
+    pub fn new() -> Self {
+        Self { last: None }
+    }
+}
+
+impl Default for PlacePipe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CadCommand for PlacePipe {
+    fn name(&self) -> &'static str {
+        "SS_PIPE"
+    }
+    fn prompt(&self) -> String {
+        if self.last.is_none() {
+            "Storm sewer pipe: pick start structure".into()
+        } else {
+            "Storm sewer pipe: pick next structure  [Esc = done]".into()
+        }
+    }
+    fn on_point(&mut self, pt: Vec3) -> CmdResult {
+        match self.last {
+            None => {
+                self.last = Some(pt);
+                CmdResult::NeedPoint
+            }
+            Some(prev) => {
+                let pipe = Line::from_points(v3(prev), v3(pt));
+                self.last = Some(pt);
+                CmdResult::CommitEntity(EntityType::Line(pipe))
+            }
+        }
+    }
+    fn on_enter(&mut self) -> CmdResult {
+        CmdResult::Cancel
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structure_commits_a_circle_and_stays_active() {
+        let mut cmd = PlaceStructure::inlet();
+        match cmd.on_point(Vec3::new(10.0, 20.0, 0.0)) {
+            CmdResult::CommitEntity(EntityType::Circle(c)) => {
+                assert_eq!(c.center.x, 10.0);
+                assert_eq!(c.center.y, 20.0);
+                assert!(c.radius > 0.0);
+            }
+            _ => panic!("expected CommitEntity(Circle)"),
+        }
+    }
+
+    #[test]
+    fn pipe_needs_two_points_then_commits_a_line() {
+        let mut cmd = PlacePipe::new();
+        assert!(matches!(cmd.on_point(Vec3::new(0.0, 0.0, 0.0)), CmdResult::NeedPoint));
+        match cmd.on_point(Vec3::new(100.0, 0.0, 0.0)) {
+            CmdResult::CommitEntity(EntityType::Line(l)) => {
+                assert_eq!(l.start.x, 0.0);
+                assert_eq!(l.end.x, 100.0);
+            }
+            _ => panic!("expected CommitEntity(Line)"),
+        }
+    }
+}


### PR DESCRIPTION
> Interest check / discussion: #78

## Summary

This adds an optional **Storm Sewer** discipline module to Open CAD Studio — a
ribbon tab for laying out and analyzing gravity storm-drain networks. It is
backed by a small, self-contained Rust engine crate (`stormsewer`) vendored
into the repo under `crates/`.

The hydraulics/hydrology are all **standard, public-domain methods** (Rational
method, Manning's equation, NRCS time-of-concentration / IDF, FHWA HEC-22-style
HGL backwater) — no proprietary algorithms.

## What's included

**`crates/stormsewer/`** — a dependency-free (`std`-only) engine library:
- circular partial-flow hydraulics (Manning, normal & critical depth, capacity),
- Rational-method peak-flow accumulation over the pipe network (Kahn topo sort),
- time-of-concentration accumulation + IDF intensity per pipe,
- HGL backwater pass from the outfall with junction losses + surcharge/flood flags,
- a `.ssn` text network parser and a CAD-agnostic plan/profile drawing generator,
- 24 unit tests, plus a small `stormsewer-cli` binary.

**`src/modules/storm_sewer/`** — the ribbon module:
- **Network** group: `SS_INLET` / `SS_JUNCTION` / `SS_OUTFALL` place structure
  markers; `SS_PIPE` chains pipe runs (interactive `CadCommand`s).
- **Analysis** group: `SS_ANALYZE` / `SS_REPORT` / `SS_PROFILE` open a `.ssn`
  file, run the engine, draw the plan + HGL long-section as entities, and print
  a report to the command line.
- SVG icons; `SS_*` registered for command-line autocomplete; 7 integration tests.

## How it integrates

The change is **additive and isolated**:
- All feature code is under `crates/stormsewer/` and `src/modules/storm_sewer/`.
- `build.rs` auto-discovers the module (the standard "add a module" path).
- The only edits to existing shared files are: `pub mod storm_sewer;` in
  `src/modules/mod.rs`, one auto-generated line in `registry.rs`, one dispatch
  block in `src/app/commands.rs`, and the workspace/dependency lines in
  `Cargo.toml`. Nothing existing is modified or removed.

## Testing

- `cargo test -p stormsewer` — 24 engine tests pass.
- `cargo test --lib storm_sewer` — 7 module integration tests pass (tab
  registration, tool presence, engine-in-binary, `.ssn` round-trip, command
  geometry).
- `cargo build --release` — clean.

## Try it

```
cargo run --release
```
Pick the **Storm Sewer** tab. Use **Analyze** and open
`crates/stormsewer/examples/sample.ssn` to see the network drawn with flow/HGL
labels and a printed report; **Profile** draws the HGL long-section.

## Notes for review

- **Licensing:** the engine crate is `GPL-3.0-or-later`, compatible with OCS.
- **Vendored vs. published:** `stormsewer` is vendored as a workspace member so
  the PR builds with no external setup. It can instead become a `crates.io`
  dependency if you'd prefer it external.
- **File dialog:** `SS_ANALYZE` uses a blocking `rfd::FileDialog`. Happy to
  switch it to the async `Message` flow used elsewhere if you prefer.
- **Follow-up (not in this PR):** the placement commands draw geometry but don't
  yet carry hydraulic data, so analysis is driven by the `.ssn` file rather than
  the drawn entities. Closing that loop via XDATA-on-entities is documented in
  `src/modules/storm_sewer/INTEGRATION.md`.

Happy to adjust scope, naming, or packaging to fit how you'd like discipline
modules to live in OCS.
