### PR TITLE
fix(windows): cast COINIT_APARTMENTTHREADED to u32 for windows-sys 0.61.2

### DIFF
--- a/src/io/file_association.rs
+++ b/src/io/file_association.rs
@@ -143,7 +143,7 @@ mod windows_impl {
 
     pub(super) fn set_default() -> Result<String, String> {
         unsafe {
-            let co = CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED);
+            let co = CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED as u32);
             // S_OK (0) / S_FALSE (1) mean we initialised COM and must balance it
             // with CoUninitialize. Any other value: another init already owns the
             // thread's apartment, so we leave it alone.


### PR DESCRIPTION
windows-sys 0.61.2 changed CoInitializeEx's dwcoinit parameter type
from i32 to u32, causing a mismatched types compile error on Windows.

https://claude.ai/code/session_01F7yMUY48VuGNUF1Q3ma2cZ