### PR TITLE
Temporarily suppress Ortho mode during RECTANG commands

### DIFF
--- a/src/app/cmd_result.rs
+++ b/src/app/cmd_result.rs
@@ -1674,12 +1674,17 @@ impl OpenCADStudio {
         self.focus_cmd_input()
     }
 
-    /// Restore the tangent snap state that was in effect before the command started.
+    /// Restore the tangent-snap / ortho state that was in effect before the command started.
     fn restore_pre_cmd_tangent(&mut self) {
         if let Some(was_on) = self.pre_cmd_tangent.take() {
             if !was_on {
                 self.snapper.enabled.remove(&crate::snap::SnapType::Tangent);
             }
+        }
+        if self.rect_suppressed_ortho {
+            self.rect_suppressed_ortho = false;
+            self.ortho_mode = true;
+            self.polar_mode = false;
         }
     }
 }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1006,18 +1006,30 @@ impl OpenCADStudio {
                 use crate::modules::draw::draw::shapes::RectCommand;
                 let new_cmd = RectCommand::new();
                 self.command_line.push_info(&new_cmd.prompt());
+                if self.ortho_mode {
+                    self.rect_suppressed_ortho = true;
+                    self.ortho_mode = false;
+                }
                 self.tabs[i].active_cmd = Some(Box::new(new_cmd));
             }
             "RECT_ROT" => {
                 use crate::modules::draw::draw::shapes::RectRotCommand;
                 let new_cmd = RectRotCommand::new();
                 self.command_line.push_info(&new_cmd.prompt());
+                if self.ortho_mode {
+                    self.rect_suppressed_ortho = true;
+                    self.ortho_mode = false;
+                }
                 self.tabs[i].active_cmd = Some(Box::new(new_cmd));
             }
             "RECT_CEN" => {
                 use crate::modules::draw::draw::shapes::RectCenCommand;
                 let new_cmd = RectCenCommand::new();
                 self.command_line.push_info(&new_cmd.prompt());
+                if self.ortho_mode {
+                    self.rect_suppressed_ortho = true;
+                    self.ortho_mode = false;
+                }
                 self.tabs[i].active_cmd = Some(Box::new(new_cmd));
             }
             "POLY" | "POLYGON" | "POL" => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -209,6 +209,8 @@ pub(super) struct OpenCADStudio {
     otrack_active: Option<(glam::Vec3, glam::Vec3)>,
     /// Whether Tangent snap was enabled before a tangent-pick command started.
     pre_cmd_tangent: Option<bool>,
+    /// Whether Ortho mode was temporarily suppressed by a command (e.g. RECTANG).
+    rect_suppressed_ortho: bool,
     /// Orthogonal drawing constraint (F8): constrains picks to 0°/90°/180°/270°.
     ortho_mode: bool,
     /// Polar tracking (F10): constrains picks to configurable angle increments.
@@ -1371,6 +1373,7 @@ impl OpenCADStudio {
             perf_hud: false,
             cycle_candidates: None,
             pre_cmd_tangent: None,
+            rect_suppressed_ortho: false,
             ortho_mode: false,
             polar_mode: false,
             polar_increment_deg: 45.0,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -4098,6 +4098,10 @@ impl OpenCADStudio {
                 if self.ortho_mode {
                     self.polar_mode = false;
                 }
+                // If the user manually toggles ortho during a command that
+                // suppressed it (e.g. RECTANG), the toggle is permanent —
+                // don't restore the pre-command state when the command ends.
+                self.rect_suppressed_ortho = false;
                 Task::none()
             }
             Message::ToggleLineweightDisplay => {


### PR DESCRIPTION
When a rectangle command (RECT, RECTANG, REC, RECT_ROT, RECT_CEN) is started with Ortho mode on, ortho is automatically turned off for the duration of the command and restored when it finishes.

If the user manually toggles ortho (F8) during the command, that toggle is treated as permanent and no auto-restore occurs on exit.

Changes:

- Added rect_suppressed_ortho: bool flag to track when a rectangle command suppressed ortho
- Set the flag and disable ortho on command start (all 3 rectangle entry points)
- Restore ortho on command exit via restore_pre_cmd_tangent
- Clear the flag on manual ToggleOrtho so user toggles are permanent