### PR TITLE
Add TORIENT command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -141,6 +141,7 @@ Status of every standard CAD command in Open CAD Studio:
 | `FIELD` | — | Auto-updating text field | ❌ |
 | `SPELL` | SP | Spell check | ❌ |
 | `ARCTEXT` | — | Text along an arc | ❌ |
+| `TORIENT` | — | Orient text for readability | ✅ |
 
 ---
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1140,7 +1140,10 @@ impl OpenCADStudio {
                         .iter()
                         .filter_map(|&h| self.tabs[i].scene.document.get_entity(h).cloned().map(|e| (h, e)))
                         .collect();
-                    let new_cmd = TorientCommand::new(handles, entities);
+                    let cam_rot = self.tabs[i].scene.camera.borrow().rotation;
+                    let right = cam_rot * glam::Vec3::X;
+                    let view_twist = right.y.atan2(right.x) as f64;
+                    let new_cmd = TorientCommand::new(handles, entities, view_twist);
                     self.command_line.push_info(&new_cmd.prompt());
                     self.tabs[i].active_cmd = Some(Box::new(new_cmd));
                 }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1122,6 +1122,30 @@ impl OpenCADStudio {
                 }
             }
 
+            "TORIENT" => {
+                let handles: Vec<_> = self.tabs[i]
+                    .scene
+                    .selected_entities()
+                    .into_iter()
+                    .map(|(h, _)| h)
+                    .collect();
+                if handles.is_empty() {
+                    use crate::modules::draw::select::SelectObjectsCommand;
+                    let cmd = SelectObjectsCommand::new("TORIENT");
+                    self.command_line.push_info(&cmd.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(cmd));
+                } else {
+                    use crate::modules::draw::modify::torient::TorientCommand;
+                    let entities: Vec<_> = handles
+                        .iter()
+                        .filter_map(|&h| self.tabs[i].scene.document.get_entity(h).cloned().map(|e| (h, e)))
+                        .collect();
+                    let new_cmd = TorientCommand::new(handles, entities);
+                    self.command_line.push_info(&new_cmd.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(new_cmd));
+                }
+            }
+
             "POINT" | "PO" => {
                 use crate::modules::draw::draw::point::PointCommand;
                 let new_cmd = PointCommand::new();

--- a/src/modules/draw/modify/mod.rs
+++ b/src/modules/draw/modify/mod.rs
@@ -20,3 +20,4 @@ pub mod splinedit;
 pub mod stretch;
 pub mod translate;
 pub mod trim;
+pub mod torient;

--- a/src/modules/draw/modify/torient.rs
+++ b/src/modules/draw/modify/torient.rs
@@ -23,14 +23,16 @@ enum Step {
 pub struct TorientCommand {
     handles: Vec<Handle>,
     entities: Vec<(Handle, EntityType)>,
+    view_twist: f64,
     step: Step,
 }
 
 impl TorientCommand {
-    pub fn new(handles: Vec<Handle>, entities: Vec<(Handle, EntityType)>) -> Self {
+    pub fn new(handles: Vec<Handle>, entities: Vec<(Handle, EntityType)>, view_twist: f64) -> Self {
         Self {
             handles,
             entities,
+            view_twist,
             step: Step::AngleOrFirstPoint,
         }
     }
@@ -44,24 +46,24 @@ impl TorientCommand {
 
             match &mut new_entity {
                 EntityType::Text(text) => {
-                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(text.rotation));
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(text.rotation, self.view_twist));
                     text.rotation = angle;
                     changed = true;
                 }
                 EntityType::MText(mtext) => {
-                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(mtext.rotation as f64));
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(mtext.rotation as f64, self.view_twist));
                     mtext.rotation = angle as f64;
                     changed = true;
                 }
                 EntityType::AttributeDefinition(attdef) => {
-                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attdef.rotation));
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attdef.rotation, self.view_twist));
                     attdef.rotation = angle;
                     changed = true;
                 }
                 EntityType::Insert(insert) => {
                     let mut block_changed = false;
                     for attr in &mut insert.attributes {
-                        let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attr.rotation));
+                        let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attr.rotation, self.view_twist));
                         attr.rotation = angle;
                         block_changed = true;
                     }
@@ -85,23 +87,30 @@ impl TorientCommand {
     }
 }
 
-fn most_readable_angle(mut angle_rad: f64) -> f64 {
+fn most_readable_angle(wcs_angle_rad: f64, view_twist: f64) -> f64 {
     let two_pi = 2.0 * std::f64::consts::PI;
-    angle_rad %= two_pi;
-    if angle_rad < 0.0 {
-        angle_rad += two_pi;
+    
+    // Calculate the angle as it appears on screen
+    let mut screen_angle = (wcs_angle_rad - view_twist) % two_pi;
+    if screen_angle < 0.0 {
+        screen_angle += two_pi;
     }
 
-    // "Most Readable" logic: if upside down (i.e. angle > 90 and <= 270 deg), rotate 180 deg
+    // "Most Readable" logic: if upside down on screen (angle > 90 and <= 270 deg)
     let half_pi = std::f64::consts::PI / 2.0;
     let three_half_pi = 3.0 * std::f64::consts::PI / 2.0;
 
-    if angle_rad > half_pi + 1e-6 && angle_rad <= three_half_pi + 1e-6 {
-        angle_rad += std::f64::consts::PI;
-        angle_rad %= two_pi;
+    let mut final_wcs_angle = wcs_angle_rad;
+    if screen_angle > half_pi + 1e-6 && screen_angle <= three_half_pi + 1e-6 {
+        final_wcs_angle += std::f64::consts::PI;
     }
     
-    angle_rad
+    // Normalize final WCS angle
+    final_wcs_angle %= two_pi;
+    if final_wcs_angle < 0.0 {
+        final_wcs_angle += two_pi;
+    }
+    final_wcs_angle
 }
 
 impl CadCommand for TorientCommand {
@@ -173,5 +182,9 @@ impl CadCommand for TorientCommand {
 
     fn dyn_spec(&self) -> Option<crate::command::DynSpec> {
         None
+    }
+
+    fn dyn_commit_as_text(&self) -> bool {
+        matches!(self.step, Step::AngleOrFirstPoint)
     }
 }

--- a/src/modules/draw/modify/torient.rs
+++ b/src/modules/draw/modify/torient.rs
@@ -1,0 +1,177 @@
+// TORIENT tool — interactive command.
+//
+// Command:  TORIENT
+//   Requires at least one entity selected before starting.
+//   Step 1: Wait for an angle (numerical input), Enter (Most Readable), or pick first point.
+//   Step 2: If first point picked, pick second point to define angle vector.
+
+use acadrust::Handle;
+use glam::Vec3;
+
+use crate::command::{CadCommand, CmdResult, DynField};
+use crate::modules::{IconKind, ModuleEvent, ToolDef};
+use crate::scene::model::wire_model::WireModel;
+use acadrust::EntityType;
+
+// ── Command implementation ─────────────────────────────────────────────────
+
+enum Step {
+    AngleOrFirstPoint,
+    SecondPoint { first_point: Vec3 },
+}
+
+pub struct TorientCommand {
+    handles: Vec<Handle>,
+    entities: Vec<(Handle, EntityType)>,
+    step: Step,
+}
+
+impl TorientCommand {
+    pub fn new(handles: Vec<Handle>, entities: Vec<(Handle, EntityType)>) -> Self {
+        Self {
+            handles,
+            entities,
+            step: Step::AngleOrFirstPoint,
+        }
+    }
+
+    fn commit_angle(&self, new_angle_rad: Option<f64>) -> CmdResult {
+        let mut replacements = Vec::new();
+
+        for (handle, entity) in &self.entities {
+            let mut new_entity = entity.clone();
+            let mut changed = false;
+
+            match &mut new_entity {
+                EntityType::Text(text) => {
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(text.rotation));
+                    text.rotation = angle;
+                    changed = true;
+                }
+                EntityType::MText(mtext) => {
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(mtext.rotation as f64));
+                    mtext.rotation = angle as f64;
+                    changed = true;
+                }
+                EntityType::AttributeDefinition(attdef) => {
+                    let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attdef.rotation));
+                    attdef.rotation = angle;
+                    changed = true;
+                }
+                EntityType::Insert(insert) => {
+                    let mut block_changed = false;
+                    for attr in &mut insert.attributes {
+                        let angle = new_angle_rad.unwrap_or_else(|| most_readable_angle(attr.rotation));
+                        attr.rotation = angle;
+                        block_changed = true;
+                    }
+                    if block_changed {
+                        changed = true;
+                    }
+                }
+                _ => {}
+            }
+
+            if changed {
+                replacements.push((*handle, vec![new_entity]));
+            }
+        }
+
+        if replacements.is_empty() {
+            CmdResult::Cancel
+        } else {
+            CmdResult::ReplaceMany(replacements, vec![])
+        }
+    }
+}
+
+fn most_readable_angle(mut angle_rad: f64) -> f64 {
+    let two_pi = 2.0 * std::f64::consts::PI;
+    angle_rad %= two_pi;
+    if angle_rad < 0.0 {
+        angle_rad += two_pi;
+    }
+
+    // "Most Readable" logic: if upside down (i.e. angle > 90 and <= 270 deg), rotate 180 deg
+    let half_pi = std::f64::consts::PI / 2.0;
+    let three_half_pi = 3.0 * std::f64::consts::PI / 2.0;
+
+    if angle_rad > half_pi + 1e-6 && angle_rad <= three_half_pi + 1e-6 {
+        angle_rad += std::f64::consts::PI;
+        angle_rad %= two_pi;
+    }
+    
+    angle_rad
+}
+
+impl CadCommand for TorientCommand {
+    fn name(&self) -> &'static str {
+        "TORIENT"
+    }
+
+    fn prompt(&self) -> String {
+        match &self.step {
+            Step::AngleOrFirstPoint => "TORIENT  New absolute rotation <Most Readable>:".into(),
+            Step::SecondPoint { .. } => "TORIENT  Specify second point:".into(),
+        }
+    }
+
+    fn on_point(&mut self, pt: Vec3) -> CmdResult {
+        match self.step {
+            Step::AngleOrFirstPoint => {
+                self.step = Step::SecondPoint { first_point: pt };
+                CmdResult::NeedPoint
+            }
+            Step::SecondPoint { first_point } => {
+                let dx = pt.x - first_point.x;
+                let dy = pt.y - first_point.y;
+                let angle = dy.atan2(dx) as f64;
+                self.commit_angle(Some(angle))
+            }
+        }
+    }
+
+    fn on_enter(&mut self) -> CmdResult {
+        match self.step {
+            Step::AngleOrFirstPoint => self.commit_angle(None),
+            Step::SecondPoint { .. } => CmdResult::Cancel,
+        }
+    }
+
+    fn on_escape(&mut self) -> CmdResult {
+        CmdResult::Cancel
+    }
+
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        if let Step::AngleOrFirstPoint = self.step {
+            let deg: f64 = text.trim().replace(',', ".").parse().ok()?;
+            Some(self.commit_angle(Some(deg.to_radians())))
+        } else {
+            None
+        }
+    }
+
+    fn on_preview_wires(&mut self, pt: Vec3) -> Vec<WireModel> {
+        if let Step::SecondPoint { first_point } = self.step {
+            vec![WireModel::solid(
+                "rubber_band".into(),
+                vec![[first_point.x, first_point.y, first_point.z], [pt.x, pt.y, pt.z]],
+                WireModel::CYAN,
+                false,
+            )]
+        } else {
+            vec![]
+        }
+    }
+
+    fn dyn_field(&self) -> DynField {
+        match self.step {
+            Step::AngleOrFirstPoint => DynField::Angle,
+            Step::SecondPoint { .. } => DynField::Point,
+        }
+    }
+
+    fn dyn_spec(&self) -> Option<crate::command::DynSpec> {
+        None
+    }
+}


### PR DESCRIPTION
This PR implements the TORIENT command, which allows users to rapidly orient selected text objects to a specific angle or make them "Most Readable" without changing their physical positions in the drawing, I use this command frequently.

- Supported Entities: Works with Text, MText, AttributeDefinition (ATTDEF), and Insert (BLOCK) references.
In-Place Attribute Rotation: For Insert blocks, it iterates through and intelligently rotates the attached Attribute objects without rotating the parent block itself.
- "Most Readable" Default: Enter applies the "Most Readable" logic, which automatically rotates upside-down text so it reads correctly relative to the viewport.
- Absolute Orientation: specify a new absolute angle by typing a numerical value or drawing a 2-point vector on the canvas.
- Selection Support: supports both pre-selection (selecting objects then running the command) and post-selection