### PR TITLE
registry: add Storm Sewer plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -3,5 +3,10 @@
     "repo": "HakanSeven12/opencad-example-plugin",
     "name": "Example Plugin",
     "description": "Reference dynamically-loaded add-on (ribbon tab + EX_HELLO command)."
+  },
+  {
+    "repo": "mf4633/opencad-storm-sewer-plugin",
+    "name": "Storm Sewer",
+    "description": "Gravity storm-drain network design and analysis (Rational + Manning + HGL, LandXML import)."
   }
 ]


### PR DESCRIPTION
Adds mf4633/opencad-storm-sewer-plugin to the curated plugin registry.

**Plugin:** https://github.com/mf4633/opencad-storm-sewer-plugin  
**Release:** v0.1.0 (analysis commands, LandXML import, SS_APPLYTC)  
**Related:** OpenCADStudio#78, #100

Built against ocs_plugin_api v1; follows the opencad-example-plugin release workflow. Interactive placement (SS_INLET/SS_PIPE) deferred pending HostApi hook discussion on #100.