### PR TITLE
Add HydroComplete to plugin marketplace registry

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -8,5 +8,10 @@
     "repo": "mf4633/opencad-storm-sewer-plugin",
     "name": "Storm Sewer",
     "description": "Gravity storm-drain network design and analysis (Rational + Manning + HGL, LandXML import)."
+  },
+  {
+    "repo": "mf4633/opencad-hydrocomplete-plugin",
+    "name": "HydroComplete",
+    "description": "Full stormwater hydrology and hydraulics — mirrors HydroComplete for Civil 3D (HC_ANALYZE, HC_REVIEW, KaTeX HTML reports, Atlas 14, BMP/WQV, LandXML)."
   }
 ]


### PR DESCRIPTION
Adds \mf4633/opencad-hydrocomplete-plugin\ to \plugins/registry.json\ alongside the existing Storm Sewer entry.

**HydroComplete** (\opencad.hydrocomplete\, API v2, v0.4.1+):
- Full hydrology/hydraulics parity with HydroComplete for Civil 3D
- \HC_ANALYZE\, \HC_REVIEW\, KaTeX HTML reports, NOAA Atlas 14, BMP/WQV, LandXML import
- Prebuilt release assets: \opencad.hydrocomplete-windows-x86_64.dll\ + \plugin.toml\

Same install pattern as \opencad-storm-sewer-plugin\ — Plugin Manager → Add repository → pick release.