### PR TITLE
registry: add Land Survey plugin

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -12,6 +12,11 @@
   {
     "repo": "mf4633/opencad-hydrocomplete-plugin",
     "name": "HydroComplete",
-    "description": "Full stormwater hydrology and hydraulics — mirrors HydroComplete for Civil 3D (HC_ANALYZE, HC_REVIEW, KaTeX HTML reports, Atlas 14, BMP/WQV, LandXML)."
+    "description": "Full stormwater hydrology and hydraulics \u2014 mirrors HydroComplete for Civil 3D (HC_ANALYZE, HC_REVIEW, KaTeX HTML reports, Atlas 14, BMP/WQV, LandXML)."
+  },
+  {
+    "repo": "KevinGriffin-new/opencad-landsurvey-plugin",
+    "name": "Land Survey",
+    "description": "Survey points, PNEZD & LandXML import, TIN surfaces, earthwork volumes, COGO, and coordinate transforms (RTS / Helmert / resection)."
   }
 ]


### PR DESCRIPTION
Adds the **Land Survey** add-on to the marketplace registry, following the LandXML discussion in #157 (LandXML kept plugin-side; Land Survey owns the surface side).

- **Repo:** https://github.com/KevinGriffin-new/opencad-landsurvey-plugin (public)
- **Releases:** v0.1.0–v0.3.1; v0.3.1 is built against the **v0.6.5** host (`ocs_plugin_api` api_version 2, `acadrust` matched from v0.6.5's lockfile) so the loaded cdylib is ABI-compatible.
- **Ribbon:** Points (PNEZD), Surface (TIN from PNEZD/LandXML → Mesh), earthwork Volumes, COGO inverse, Transform (RTS / Helmert), Resection (free-station), Plan import.

Single-object addition to `plugins/registry.json`:

```json
{
  "repo": "KevinGriffin-new/opencad-landsurvey-plugin",
  "name": "Land Survey",
  "description": "Survey points, PNEZD & LandXML import, TIN surfaces, earthwork volumes, COGO, and coordinate transforms (RTS / Helmert / resection)."
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)