### PR TITLE
fix(dimension): bake a *D block on save so dimensions survive in other CAD

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -465,6 +465,7 @@ pub fn save_as_version(
     let mut doc = doc.clone();
     doc.version = version;
     sync_current_styles_on_save(&mut doc);
+    crate::modules::draw::modify::explode::bake_dimension_blocks(&mut doc);
     let ext = path
         .extension()
         .map(|e| e.to_string_lossy().to_lowercase())
@@ -496,6 +497,7 @@ pub fn save_to_bytes(
     let mut doc = doc.clone();
     doc.version = version;
     sync_current_styles_on_save(&mut doc);
+    crate::modules::draw::modify::explode::bake_dimension_blocks(&mut doc);
     match ext.to_lowercase().as_str() {
         "dxf" => DxfWriter::new(&doc).write_to_vec().map_err(|e| e.to_string()),
         _ => {

--- a/src/modules/draw/modify/explode.rs
+++ b/src/modules/draw/modify/explode.rs
@@ -18,9 +18,11 @@ use std::f64::consts::TAU;
 
 use acadrust::entities::EntityCommon;
 use acadrust::entities::{
-    Arc as ArcEnt, Circle as CircleEnt, Dimension, Line as LineEnt, LwPolyline, MLine,
+    Arc as ArcEnt, Block, BlockEnd, Circle as CircleEnt, Dimension, Line as LineEnt, LwPolyline,
+    MLine,
 };
 use acadrust::entities::{Polyline, Polyline2D};
+use acadrust::tables::BlockRecord;
 use acadrust::types::Vector3;
 use acadrust::{CadDocument, EntityType, Handle};
 
@@ -428,6 +430,105 @@ fn explode_dimension(dim: &Dimension) -> Vec<EntityType> {
     result
 }
 
+// ── Dimension block baking (DWG/DXF interop) ────────────────────────────────
+
+/// Smallest free `*D<n>` anonymous block name in `doc`.
+fn next_dimension_block_name(doc: &CadDocument) -> String {
+    let mut n = 0u64;
+    loop {
+        let cand = format!("*D{n}");
+        if doc.block_records.get(&cand).is_none() {
+            return cand;
+        }
+        n += 1;
+    }
+}
+
+/// Bake an anonymous `*D<n>` geometry block for every DIMENSION that doesn't
+/// already own one, so the file is valid for AutoCAD-family readers.
+///
+/// OCS renders dimensions by re-tessellating them on the fly and never
+/// materialises the `*D` block that a DWG `DIMENSION` is supposed to reference
+/// (the lines / arrows / text that AutoCAD actually draws). A dimension created
+/// in OCS therefore goes out referencing a block that doesn't exist, and the
+/// writer emits a null block handle — strict readers (DWG TrueView, QCAD) drop
+/// the dimension or demand a recovery, and lenient ones (BricsCAD) regenerate it
+/// at a different position. Call this on the document about to be written so each
+/// such dimension gets a real block built from its exploded geometry (extension
+/// lines + dimension line + measurement text, the same decomposition EXPLODE
+/// uses) and its `block_name` points at it.
+///
+/// Dimensions that already reference an existing block (e.g. imported from a real
+/// DWG, or copied via the `*D`-cloning copy path) are left untouched so their
+/// original graphics are preserved.
+pub fn bake_dimension_blocks(doc: &mut CadDocument) {
+    // Handles of dimensions whose block reference is missing or dangling.
+    let pending: Vec<Handle> = doc
+        .entities()
+        .filter_map(|e| match e {
+            EntityType::Dimension(d) => {
+                let bn = &d.base().block_name;
+                if bn.trim().is_empty() || doc.block_records.get(bn).is_none() {
+                    Some(d.base().common.handle)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .collect();
+
+    for handle in pending {
+        let dim = match doc.get_entity(handle) {
+            Some(EntityType::Dimension(d)) => d.clone(),
+            _ => continue,
+        };
+        let subs = explode_dimension(&dim);
+        if subs.is_empty() {
+            continue;
+        }
+
+        let name = next_dimension_block_name(doc);
+        // Reserve three consecutive handles for the record / block / endblk.
+        // Adding the block + endblk (which carry explicit handles) advances the
+        // document's handle counter past them, so the NULL-handle sub-entities
+        // added afterwards get fresh handles without colliding.
+        let next = doc.next_handle();
+        let br_handle = Handle::new(next);
+        let block_handle = Handle::new(next + 1);
+        let end_handle = Handle::new(next + 2);
+
+        let mut br = BlockRecord::new(&name);
+        br.handle = br_handle;
+        br.block_entity_handle = block_handle;
+        br.block_end_handle = end_handle;
+        br.flags.anonymous = true;
+        if doc.block_records.add(br).is_err() {
+            continue;
+        }
+
+        let mut block = Block::new(&name, Vector3::new(0.0, 0.0, 0.0));
+        block.common.handle = block_handle;
+        block.common.owner_handle = br_handle;
+        let _ = doc.add_entity(EntityType::Block(block));
+
+        let mut block_end = BlockEnd::new();
+        block_end.common.handle = end_handle;
+        block_end.common.owner_handle = br_handle;
+        let _ = doc.add_entity(EntityType::BlockEnd(block_end));
+
+        for mut sub in subs {
+            sub.common_mut().handle = Handle::NULL;
+            sub.common_mut().owner_handle = br_handle;
+            let _ = doc.add_entity(sub);
+        }
+
+        if let Some(EntityType::Dimension(d)) = doc.get_entity_mut(handle) {
+            d.base_mut().block_name = name;
+        }
+    }
+}
+
 // ── Command stub (kept for future interactive selection mode) ───────────────
 
 pub struct ExplodeCommand;
@@ -455,5 +556,48 @@ impl CadCommand for ExplodeCommand {
     }
     fn on_escape(&mut self) -> CmdResult {
         CmdResult::Cancel
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acadrust::entities::DimensionLinear;
+
+    /// A dimension created without a geometry block gets a real `*D` block on
+    /// bake, its `block_name` resolves to that block, and a second bake is a
+    /// no-op (already has a valid block).
+    #[test]
+    fn bakes_block_for_blockless_dimension_and_is_idempotent() {
+        let mut doc = CadDocument::new();
+
+        let mut d = DimensionLinear::new(Vector3::new(0.0, 0.0, 0.0), Vector3::new(10.0, 0.0, 0.0));
+        d.definition_point = Vector3::new(0.0, 5.0, 0.0);
+        d.base.text_middle_point = Vector3::new(5.0, 5.0, 0.0);
+        // block_name is left empty — exactly what OCS-created dimensions carry.
+        let handle = doc
+            .add_entity(EntityType::Dimension(Dimension::Linear(d)))
+            .unwrap();
+
+        bake_dimension_blocks(&mut doc);
+
+        let block_name = match doc.get_entity(handle) {
+            Some(EntityType::Dimension(d)) => d.base().block_name.clone(),
+            _ => panic!("dimension missing"),
+        };
+        assert!(!block_name.trim().is_empty(), "block_name should be set");
+        assert!(
+            doc.block_records.get(&block_name).is_some(),
+            "baked block must exist in the block table"
+        );
+
+        // Second pass must not create another block for the same dimension.
+        let before = doc.block_records.len();
+        bake_dimension_blocks(&mut doc);
+        assert_eq!(
+            doc.block_records.len(),
+            before,
+            "a dimension that already owns a block must not be re-baked"
+        );
     }
 }


### PR DESCRIPTION
## Bake an anonymous `*D` block for dimensions on save (fixes #178, #181, #182)

### Problem

A DWG `DIMENSION` entity doesn't carry its own graphics — the extension lines,
dimension line, arrowheads and text live in an anonymous `*D<n>` block that the
dimension references, and Other CAD software readers render *that block*. OCS draws
dimensions by re-tessellating them on the fly (see the note in
`entities/dimension.rs`: *"the dim graphics — we re-tessellate so don't need
it"*) and never materialises the `*D` block. On save, `io::save_as_version`
only style-syncs the cloned document before handing it to the writer, so a
dimension created in OCS goes out referencing a block that doesn't exist, and
the writer emits a **null block handle**.

Result, reproduced from the attached sample files:

- **DWG TrueView 2018** opens the file *without* the dimensions (#182)
- **DWG TrueView 2013** reports the file needs recovery, then fails to open (#182)
- **QCAD / TrueView** crash or freeze on a saved copy (#178)
- **BricsCAD** renders the dimensions but **regenerates them at different
  positions**, ignoring node-edited dimension lines (#181)

Confirmed directly in Other CAD software: the OCS file raises an
*"Open – Foreign DWG File"* prompt and then contains **0 DIMENSION entities**;
a healthy DWG from other CAD software has one `*D<n>` block (≈7 sub-entities) per
dimension.

### Fix

Add `bake_dimension_blocks()` (in `modules/draw/modify/explode.rs`, beside the
existing `explode_dimension`) and call it on the cloned document in
`io::save_as_version` and `io::save_to_bytes`, right after the style sync.

For every dimension whose `block_name` is empty or doesn't resolve, it:

1. explodes the dimension into its constituent entities (extension lines +
   dimension line + measurement text — the same decomposition `EXPLODE` uses),
2. creates an anonymous `*D<n>` `BlockRecord` + `Block` + `BlockEnd` that own
   those sub-entities (the same wiring the `#161` copy path uses), and
3. points the dimension's `block_name` at the new block.

Dimensions that already reference an existing block (imported from a real DWG,
or copied via the `*D`-cloning copy path) are left untouched, so their original
graphics are preserved. The pass runs on the **clone** the save path already
makes, so the live document is unaffected.

### Verification

- New unit test (`bakes_block_for_blockless_dimension_and_is_idempotent`):
  a block-less dimension gets a resolvable `*D` block, and a second pass is a
  no-op.
- End-to-end on the #182 sample: before the fix, Civil 3D 2026 reads **0**
  dimensions from the OCS file; after baking, it reads **all 3** (and the
  re-read DWG shows three `*D` blocks with `block_exists = true` for every
  dimension).

Closes #178, #181, #182.
