### PR TITLE
fix(shortcuts): honor Cmd as the accelerator modifier on macOS

### DIFF
--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -1449,7 +1449,11 @@ impl OpenCADStudio {
                         text,
                         ..
                     }) => {
-                        let ctrl = modifiers.control();
+                        // Platform-aware accelerator modifier: Cmd on macOS,
+                        // Ctrl on Windows/Linux. Using `command()` rather than
+                        // `control()` makes Cmd+C/V/S/Z etc. work on Mac, per
+                        // the platform's keyboard conventions.
+                        let accel = modifiers.command();
                         let shift = modifiers.shift();
                         // Any key that produces a printable glyph types it,
                         // even when its logical key resolves to navigation
@@ -1459,7 +1463,7 @@ impl OpenCADStudio {
                         // those numpad digits aren't swallowed as history
                         // navigation. Whitespace / control text (Space,
                         // Enter, Tab) falls through to the named handlers.
-                        if !ctrl && status == Status::Ignored {
+                        if !accel && status == Status::Ignored {
                             if let Some(t) = text.as_deref() {
                                 if !t.is_empty()
                                     && t.chars().all(|c| !c.is_control() && !c.is_whitespace())
@@ -1543,7 +1547,7 @@ impl OpenCADStudio {
                             keyboard::Key::Named(keyboard::key::Named::F12) => {
                                 Some(Message::ToggleDynInput)
                             }
-                            keyboard::Key::Character(c) if ctrl => match c.as_str() {
+                            keyboard::Key::Character(c) if accel => match c.as_str() {
                                 "n" => Some(Message::TabNew),
                                 "o" => Some(Message::OpenFile),
                                 "s" if !shift => Some(Message::SaveFile),

--- a/src/ui/window/shortcuts.rs
+++ b/src/ui/window/shortcuts.rs
@@ -3,6 +3,16 @@
 use crate::app::Message;
 use iced::widget::{column, container, row, scrollable, text, Space};
 use iced::{Background, Color, Element, Fill, Theme};
+use std::borrow::Cow;
+
+/// Display name of the primary accelerator modifier on this platform.
+/// Mirrors the runtime binding in `app::view`, which uses
+/// `Modifiers::command()` — the Cmd key on macOS, Ctrl elsewhere — so the
+/// reference window shows the key the user actually presses.
+#[cfg(target_os = "macos")]
+const MOD: &str = "Cmd";
+#[cfg(not(target_os = "macos"))]
+const MOD: &str = "Ctrl";
 
 const TB: Color = Color {
     r: 0.13,
@@ -52,9 +62,12 @@ fn hdivider<'a>() -> Element<'a, Message> {
         .into()
 }
 
-fn shortcut_row<'a>(key: &'static str, action: &'static str) -> Element<'a, Message> {
+fn shortcut_row<'a>(
+    key: impl Into<Cow<'static, str>>,
+    action: &'static str,
+) -> Element<'a, Message> {
     row![
-        text(key)
+        text(key.into())
             .size(11)
             .color(KEY)
             .font(iced::Font::MONOSPACE)
@@ -67,8 +80,8 @@ fn shortcut_row<'a>(key: &'static str, action: &'static str) -> Element<'a, Mess
     .into()
 }
 
-fn section<'a>(title: &'static str) -> Element<'a, Message> {
-    container(text(title).size(11).color(DIM))
+fn section<'a>(title: impl Into<Cow<'static, str>>) -> Element<'a, Message> {
+    container(text(title.into()).size(11).color(DIM))
         .padding(iced::Padding {
             top: 6.0,
             right: 0.0,
@@ -107,16 +120,18 @@ pub fn view_window<'a>(
         shortcut_row("F10", "Toggle Polar Tracking"),
         shortcut_row("F11", "Toggle Object Snap Tracking"),
         shortcut_row("F12", "Toggle Dynamic Input"),
-        section("── Ctrl Shortcuts ──────────────────────────────────────"),
-        shortcut_row("Ctrl+N", "New Drawing"),
-        shortcut_row("Ctrl+O", "Open File"),
-        shortcut_row("Ctrl+S", "Save"),
-        shortcut_row("Ctrl+Shift+S", "Save As"),
-        shortcut_row("Ctrl+Z", "Undo"),
-        shortcut_row("Ctrl+Shift+Z / Ctrl+Y", "Redo"),
-        shortcut_row("Ctrl+C", "Copy to Clipboard"),
-        shortcut_row("Ctrl+X", "Cut to Clipboard"),
-        shortcut_row("Ctrl+V", "Paste from Clipboard"),
+        section(format!(
+            "── {MOD} Shortcuts ──────────────────────────────────────"
+        )),
+        shortcut_row(format!("{MOD}+N"), "New Drawing"),
+        shortcut_row(format!("{MOD}+O"), "Open File"),
+        shortcut_row(format!("{MOD}+S"), "Save"),
+        shortcut_row(format!("{MOD}+Shift+S"), "Save As"),
+        shortcut_row(format!("{MOD}+Z"), "Undo"),
+        shortcut_row(format!("{MOD}+Shift+Z / {MOD}+Y"), "Redo"),
+        shortcut_row(format!("{MOD}+C"), "Copy to Clipboard"),
+        shortcut_row(format!("{MOD}+X"), "Cut to Clipboard"),
+        shortcut_row(format!("{MOD}+V"), "Paste from Clipboard"),
         section("── Other Keys ──────────────────────────────────────────"),
         shortcut_row("Enter / Space", "Finalize command / Repeat last"),
         shortcut_row("Escape", "Cancel active command"),


### PR DESCRIPTION
Closes #202

## Problem

On macOS, the keyboard accelerators (⌘N, ⌘O, ⌘S, ⌘⇧S, ⌘Z, ⌘⇧Z/⌘Y, ⌘C, ⌘X, ⌘V) did nothing. The key handler in `src/app/view/mod.rs` gated accelerators on `modifiers.control()`, which on macOS matches only the physical **Control** key — not **Cmd**. As a result, pressing ⌘+letter fell through to the command-line text handler, so the letter was typed into the command line (and the autocomplete popup appeared) instead of running the shortcut.

## Fix

- **`src/app/view/mod.rs`** — gate accelerators on `modifiers.command()` instead of `modifiers.control()`. iced's `Modifiers::command()` is platform-aware: it maps to Logo/Cmd on macOS and Ctrl on Windows/Linux. Because `command()` is `cfg`-gated to `control()` off macOS, Windows/Linux behavior is unchanged and only macOS gains Cmd support.
- **`src/ui/window/shortcuts.rs`** — the Keyboard Shortcuts reference window hard-coded "Ctrl+…" labels; they now render "Cmd+…" on macOS via a `cfg` const, so the help matches the keys actually pressed.

## Testing

Built and run on macOS (Apple Silicon; iced 0.14 / winit 0.30):

- ⌘N opens a new drawing tab, ⌘O opens the file-open dialog, ⌘S opens the save dialog.
- Physical **Ctrl+N / Ctrl+O no longer trigger** these (correct — Cmd is the macOS convention).
- The Keyboard Shortcuts window now reads "Cmd+…".
- Bug reproduced on the **v0.6.8** release prior to the fix.

No behavioral change on Windows/Linux — `command()` expands to `control()` there.
