### PR TITLE
fix(scene): keep explicit inline text colours through block colour inheritance

### DIFF
--- a/src/scene/cache/block_cache.rs
+++ b/src/scene/cache/block_cache.rs
@@ -467,6 +467,13 @@ fn tessellate_sub_local(
         );
         let is_fill_only = wire.points.is_empty() && !wire.fill_tris.is_empty();
 
+        // A wire whose colour differs from the entity's resolved base colour
+        // carries an explicit per-segment override (e.g. an MTEXT `\C1;` inline
+        // colour). ByBlock / layer-0 inheritance only applies to wires still on
+        // the base colour — folding explicit segments into the inherited colour
+        // collapses colour-split text to one colour.
+        let wire_on_base_color = wire.color == sub_color;
+
         result.push(LocalWire {
             points: wire.points,
             points_low: wire.points_low,
@@ -482,10 +489,10 @@ fn tessellate_sub_local(
             line_weight_px: lw_px,
             plinegen: wire.plinegen,
             is_fill_only,
-            color_is_byblock,
+            color_is_byblock: color_is_byblock && wire_on_base_color,
             lt_is_byblock,
             lw_is_byblock,
-            color_l0,
+            color_l0: color_l0 && wire_on_base_color,
             lt_l0,
             lw_l0,
             aabb_local,

--- a/tests/text_font_rendering.rs
+++ b/tests/text_font_rendering.rs
@@ -3,6 +3,7 @@ use acadrust::tables::{BlockRecord, TextStyle};
 use acadrust::types::Vector3;
 use acadrust::{CadDocument, EntityType, Handle};
 use OpenCADStudio::scene::cache::block_cache::{expand_insert, BlockCache};
+use OpenCADStudio::scene::view::render::InheritStyle;
 use OpenCADStudio::scene::WireModel;
 
 fn drawable_point_count(wires: &[WireModel]) -> usize {
@@ -51,6 +52,14 @@ fn expand_block_mtext(
         0.0,
         [0.0; 8],
         1.0,
+        // The INSERT sits on layer "0" which resolves to the white/Continuous
+        // fallback — matching the resolved style passed above.
+        InheritStyle {
+            color: [1.0, 1.0, 1.0, 1.0],
+            pat_len: 0.0,
+            pat: [0.0; 8],
+            lw_px: 1.0,
+        },
         false,
         1.0,
         None,


### PR DESCRIPTION
## Summary

Block-nested MTEXT with inline colour codes (`\C1;`, `\C2;`, …) currently renders in a single colour: the layer-0 / ByBlock colour-inheritance flags (`color_l0`, `color_is_byblock`) are computed per **entity** in the block cache, so `resolve_wire_color` replaces every wire's colour with the inherited colour at emit time — including segments whose colour comes from an explicit inline override. Colour-split text inside a block collapses to one colour.

This went unnoticed because the regression test guarding exactly this (`tests/text_font_rendering.rs`, `block_nested_colour_split_mtext_keeps_per_wire_colour`) stopped compiling when `expand_insert` gained the `InheritStyle` layer-0 parameter (E0061 on current `main`), so it never ran.

## Changes

- **`src/scene/cache/block_cache.rs`**: only apply ByBlock / layer-0 colour inheritance to wires still carrying the entity's resolved base colour. A wire whose colour differs from the base carries an explicit per-segment override (e.g. an MTEXT `\C` code) and keeps it. Linetype/lineweight inheritance is unaffected.
- **`tests/text_font_rendering.rs`**: update the `expand_insert` call site to pass the INSERT's layer-0 `InheritStyle` (white / Continuous / 1 px — what layer "0" resolves to in the test document), matching the production caller in `tess.rs`. The test suite compiles again.

## Testing

- `cargo test --test text_font_rendering` — 3/3 pass (colour-split test fails without the block_cache change, all three fail to compile without the call-site fix)
- Full `cargo test` — green (155 + 155 unit tests, all integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)