### PR TITLE
feat(manage): surface About in the ribbon — Application group (#302)

### DIFF
--- a/src/modules/draw/mod.rs
+++ b/src/modules/draw/mod.rs
@@ -1,6 +1,5 @@
 // Draw module — Draw, Modify, Annotation and Layer tools.
 
-mod about;
 mod changelog;
 pub mod clipboard;
 pub mod defaults;

--- a/src/modules/manage/about.rs
+++ b/src/modules/manage/about.rs
@@ -1,6 +1,5 @@
 use crate::modules::{IconKind, ModuleEvent, ToolDef};
 
-#[allow(dead_code)]
 pub fn tool() -> ToolDef {
     ToolDef {
         id: "ABOUT",

--- a/src/modules/manage/mod.rs
+++ b/src/modules/manage/mod.rs
@@ -1,5 +1,6 @@
 // Manage module — customization and drawing cleanup tools.
 
+mod about;
 mod audit;
 mod cui_export;
 mod cui_import;
@@ -74,6 +75,11 @@ impl CadModule for ManageModule {
                         RibbonItem::Tool(overkill::tool()),
                         RibbonItem::Tool(audit::tool()),
                     ],
+                },
+                // ── Application ───────────────────────────────────────────────────
+                RibbonGroup {
+                    title: "Application",
+                    tools: vec![RibbonItem::LargeTool(about::tool())],
                 },
             ]
         })


### PR DESCRIPTION
The ABOUT command and its version-reporting window already exist, but the ToolDef sat dead-code in the draw module with no ribbon entry, so the only way in was typing ABOUT. Move it to the manage module and give it an Application group on the Manage tab, as a discoverable fallback for version diagnostics.