### PR TITLE
Bug fixes (text/dimension), SVG export, solid persistence, CI & tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+# Build, test, and lint on every push to main and on every pull request.
+# release.yml only runs when a release is published, so nothing guarded the
+# build between releases — a compile break or a failing test could sit on
+# main unnoticed. This workflow closes that gap.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    name: Build & test (Linux)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (with clippy + rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      # Same system libraries the release AppImage build installs — iced /
+      # wgpu / fontconfig need them to link, even for `cargo test`.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev libxrandr-dev \
+            libxkbcommon-dev libwayland-dev libfontconfig1-dev libfreetype6-dev
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --workspace --all-targets
+
+      - name: Test
+        run: cargo test --workspace
+
+      # Clippy runs without `-D warnings` for now: the codebase has never been
+      # gated on it, so a blanket deny would fail on pre-existing lints. This
+      # step still surfaces clippy findings as annotations and fails on genuine
+      # clippy *errors*. Tighten to `-- -D warnings` once the backlog is clear.
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets
+
+      # Formatting is intentionally NON-blocking: Open CAD Studio uses
+      # deliberate manual formatting (hand-aligned comment blocks) that
+      # `rustfmt` would rewrite, so a `--check` gate would always be red.
+      # This step reports drift for reviewers without failing the build.
+      - name: Format check (informational)
+        continue-on-error: true
+        run: cargo fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+      # Fast compile-check of the optional `profile` feature (puffin spans) so
+      # the feature-gated code can't rot unnoticed. `check`, not `build` — just
+      # enough to catch breakage without a second full link.
+      - name: Check profile feature
+        run: cargo check --features profile
+
       # Clippy runs without `-D warnings` for now: the codebase has never been
       # gated on it, so a blanket deny would fail on pre-existing lints. This
       # step still surfaces clippy findings as annotations and fails on genuine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,8 @@ dependencies = [
  "lzma-sys",
  "open",
  "printpdf",
+ "puffin",
+ "puffin_http",
  "rayon",
  "rfd",
  "rustc-hash 2.1.2",
@@ -1088,6 +1090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2827,6 +2838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05304f8e67dfc93d1b4b990137fd1a7a4c6ad44b60a9c486c8c4486f9d2027ae"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,6 +4153,36 @@ checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "puffin"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9dae7b05c02ec1a6bc9bcf20d8bc64a7dcbf57934107902a872014899b741f"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "cfg-if",
+ "itertools 0.10.5",
+ "lz4_flex 0.11.6",
+ "once_cell",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "puffin_http"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739a3c7f56604713b553d7addd7718c226e88d598979ae3450320800bd0e9810"
+dependencies = [
+ "anyhow",
+ "crossbeam-channel",
+ "log",
+ "parking_lot",
+ "puffin",
 ]
 
 [[package]]
@@ -5990,7 +6037,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "flate2",
- "lz4_flex",
+ "lz4_flex 0.7.5",
  "nom 3.2.1",
  "num-derive 0.3.3",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,15 @@ truck-shapeops = "0.4"
 # Fast non-cryptographic hasher. Handle/u64 keys dominate the hot block,
 # hatch, draw-depth and wire caches; the default SipHash is overkill there.
 rustc-hash = "2"
+# Frame profiler (Phase 5.1) — pulled in only under `--features profile`.
+# `dep:` keeps it out of every normal build; the spans compile to no-ops.
+puffin = { version = "0.19", optional = true }
+puffin_http = { version = "0.16", optional = true }
+
+[features]
+# Enable puffin spans + a puffin_http server for live flamegraph capture.
+# Build with `cargo run --features profile`, then attach `puffin_viewer`.
+profile = ["dep:puffin", "dep:puffin_http"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A CAD application for 2D drafting and 3D modeling, built with Rust. Reads and wr
 - **STEP AP203** export (`STEPOUT`)
 - **OBJ** import (`IMPORTOBJ`)
 - **PDF** export (plot layouts to PDF)
-- **SVG** export (`SVGOUT` / `EXPORTSVG`) — model-space vector export for the web, docs, and laser cutting
+- **SVG** export (`SVGOUT` / `EXPORTSVG`) — vector export for the web, docs, and laser cutting; exports model space (auto-fit) or the active paper-space layout (paper-sized sheet, print-adapted colours, hatch fills, lineweights)
 - **WBLOCK** — write selected entities or a block to an external file
 - **XREF** — attach, reload, and auto-resolve external references
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A CAD application for 2D drafting and 3D modeling, built with Rust. Reads and wr
 - **STEP AP203** export (`STEPOUT`)
 - **OBJ** import (`IMPORTOBJ`)
 - **PDF** export (plot layouts to PDF)
+- **SVG** export (`SVGOUT` / `EXPORTSVG`) — model-space vector export for the web, docs, and laser cutting
 - **WBLOCK** — write selected entities or a block to an external file
 - **XREF** — attach, reload, and auto-resolve external references
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,12 +83,19 @@ the biggest unrealized win. Lives in the upstream fork.
 **Order:** profile first — is this really the largest slice? Measure with
 `puffin`.
 
-### 1.6 Defer raster image decode
+### 1.6 Defer raster image decode ✅ DONE
 
-[`build_derived_caches`](src/scene/mod.rs#L177-L186) calls
-`ImageModel::from_raster_image` for every `RasterImage` entity — pixel
-decode happens up front. Wasted if the entity is off-screen. Defer the
-decode until **first render** (per-handle lazy `OnceCell`).
+`build_derived_caches` still walks every `RasterImage`, but
+`ImageModel::from_raster_image` now builds only the (cheap, entity-derived)
+quad geometry — the pixel decode is deferred to the first GPU upload.
+`ImageModel` holds an `Arc<OnceLock<Option<Decoded>>>`; `decoded()` runs
+`load_pixels` on first access and caches it, and the `Arc` is shared across
+clones (the per-frame `images_arc` snapshot) so a decode happens at most
+once. An off-screen image whose quad is culled before `ImageGpu::new` never
+decodes, so opening an image-heavy drawing no longer pays the decode +
+memory cost up front. A missing/undecodable file resolves to `None` (the
+quad doesn't render), matching the old "excluded on decode failure" result
+without the eager file read.
 
 ### 1.7 File-hash cache (warm re-open)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -359,13 +359,27 @@ single `FxHashMap<Handle, u32>` translation table — cache-friendlier.
 
 Don't start any of the above **without measuring first**.
 
-### 5.1 Add `puffin` or `tracy` spans
+### 5.1 Add `puffin` or `tracy` spans ✅ DONE
 
-- `io::open_path_with_phase` → `parse`, `purge`, `caches` spans.
-- `Scene::wires_for_block` → `block_cache`, `tess`, `sort` spans.
-- `Pipeline::prepare` → `upload`, `cull`, `draw` spans.
+`puffin` spans behind a `--features profile` flag (chosen over `debug_assertions`
+so normal debug builds carry zero profiling cost — the deps are `dep:`-gated and
+the `crate::profile_scope!` macro compiles to nothing without the feature). With
+the feature, `profiling::init` starts a `puffin_http` server so `puffin_viewer`
+attaches for a live flamegraph, and `profiling::finish_frame` (end of the
+`shader::Primitive::render` pass) advances the profiler timeline.
 
-Gate behind `debug_assertions` or a `--features profile` flag.
+Instrumented:
+
+- `io::open_path_with_phase` → `io::parse` / `io::purge` / `io::caches`.
+- Wire tessellation entry → `scene::build_viewports` and per-tile
+  `scene::model_tile_wires` (near-zero on a cache hit, so it isolates the
+  re-tessellation miss cost — the same slice the PERF HUD times).
+- `Pipeline::prepare` → `pipeline::prepare` (whole GPU-prep) + a
+  `pipeline::cull` sub-span over the scissor / LOD compute block; the draw
+  pass is `pipeline::render`.
+
+Still open: finer `pipeline::upload` sub-spans per buffer, and GPU-side
+timestamp queries (the CPU submission cost is covered; GPU-wait is not).
 
 ### 5.2 Open-time breakdown log ✅ DONE
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -325,12 +325,23 @@ set. Hardware instancing:
 
 Typical architectural DWGs: 10-100× faster.
 
-### 3.5 Glyph-stroke batching
+### 3.5 Glyph-stroke batching ✅ DONE (already satisfied by the LFF engine)
 
-`tessellate.rs` produces one `WireModel` per glyph stroke today — one text
-entity = dozens of models. Cache stroke geometry per font once
-(`HashMap<(font, glyph), Vec<Point2>>`), then per-text only a transform
-matters.
+This describes the pre-LFF (CXF) state; the current architecture already
+does everything it asks:
+
+- **Glyph geometry is cached per font, process-wide.** `lff::get_font`
+  returns a `&'static Font` from a once-initialized `FONTS` map; parsing
+  runs once and `Font::glyph(c)` hands back the cached `Glyph::strokes`
+  (glyph-unit polylines) — the `HashMap<(font, glyph), …>` the item asks
+  for.
+- **Per-text work is transform-only.** `lff::tessellate_text_run` reuses the
+  cached strokes and applies just an affine `xform` (origin / scale /
+  rotation / oblique / width-factor) per character — no re-tessellation.
+- **Text emits one `WireModel` per colour-bin, not per stroke.**
+  `tessellate.rs` bins strokes (NaN-separated) by inline-colour override, so
+  a plain text/MTEXT is a single wire; Phase 3.3's batched wire pipeline then
+  collapses those into single draw calls.
 
 ---
 

--- a/src/app/cmd_result.rs
+++ b/src/app/cmd_result.rs
@@ -1116,28 +1116,6 @@ impl OpenCADStudio {
                     .push_output(&format!("STRETCH: {count} entity(ies) stretched."));
                 self.refresh_properties();
             }
-            // ── Solid3D creation (BOX / SPHERE / CYLINDER) ────────────────
-            CmdResult::CommitSolid3D { mesh_fn } => {
-                use crate::modules::insert::solid3d_cmds::empty_solid3d;
-                self.push_undo_snapshot(i, "SOLID3D");
-                let entity = empty_solid3d();
-                let handle = self.tabs[i].scene.add_entity(entity);
-                if !handle.is_null() {
-                    let name = format!("{}", handle.value());
-                    let color = [0.6f32, 0.6, 0.8, 1.0]; // default colour; command embedded it
-                    let _ = color; // color is captured inside mesh_fn
-                    if let Some(mesh) = mesh_fn(name) {
-                        self.tabs[i].scene.meshes.insert(handle, crate::scene::MeshLodSet::from_single(mesh));
-                    }
-                    self.tabs[i].dirty = true;
-                    self.command_line.push_output("Solid created.");
-                }
-                self.tabs[i].active_cmd = None;
-                self.tabs[i].snap_result = None;
-                self.tabs[i].scene.clear_preview_wire();
-                self.restore_pre_cmd_tangent();
-            }
-
             // ── EXTRUDE ────────────────────────────────────────────────────
             CmdResult::ExtrudeEntity {
                 handle,
@@ -1145,7 +1123,6 @@ impl OpenCADStudio {
                 color,
             } => {
                 use crate::entities::traits::EntityTypeOps;
-                use crate::modules::insert::solid3d_cmds::empty_solid3d;
                 use crate::scene::acad_to_truck::TruckObject;
                 use crate::scene::truck_tess;
                 use truck_modeling::builder;
@@ -1182,12 +1159,13 @@ impl OpenCADStudio {
                             _ => None,
                         }
                     });
-                    if let Some(mut mesh) = result {
+                    if let Some(mesh) = result {
                         self.push_undo_snapshot(i, "EXTRUDE");
-                        let new_entity = empty_solid3d();
-                        let new_handle = self.tabs[i].scene.add_entity(new_entity);
-                        mesh.name = format!("{}", new_handle.value());
-                        self.tabs[i].scene.meshes.insert(new_handle, crate::scene::MeshLodSet::from_single(mesh));
+                        // Persist as a Mesh entity so the solid survives save/reload;
+                        // add_entity re-tessellates it into scene.meshes for display.
+                        let woff = self.tabs[i].scene.world_offset;
+                        let entity = crate::scene::mesh_tess::mesh_entity_from_model(&mesh, woff);
+                        self.tabs[i].scene.add_entity(entity);
                         self.tabs[i].dirty = true;
                         self.command_line.push_output("EXTRUDE: solid created.");
                     } else {
@@ -1211,7 +1189,6 @@ impl OpenCADStudio {
                 color,
             } => {
                 use crate::entities::traits::EntityTypeOps;
-                use crate::modules::insert::solid3d_cmds::empty_solid3d;
                 use crate::scene::acad_to_truck::TruckObject;
                 use crate::scene::truck_tess;
                 use truck_modeling::builder;
@@ -1257,12 +1234,13 @@ impl OpenCADStudio {
                             _ => None,
                         }
                     });
-                    if let Some(mut mesh) = result {
+                    if let Some(mesh) = result {
                         self.push_undo_snapshot(i, "REVOLVE");
-                        let new_entity = empty_solid3d();
-                        let new_handle = self.tabs[i].scene.add_entity(new_entity);
-                        mesh.name = format!("{}", new_handle.value());
-                        self.tabs[i].scene.meshes.insert(new_handle, crate::scene::MeshLodSet::from_single(mesh));
+                        // Persist as a Mesh entity so the solid survives save/reload;
+                        // add_entity re-tessellates it into scene.meshes for display.
+                        let woff = self.tabs[i].scene.world_offset;
+                        let entity = crate::scene::mesh_tess::mesh_entity_from_model(&mesh, woff);
+                        self.tabs[i].scene.add_entity(entity);
                         self.tabs[i].dirty = true;
                         self.command_line
                             .push_output(&format!("REVOLVE: solid created ({:.0}°).", angle_deg));
@@ -1286,7 +1264,6 @@ impl OpenCADStudio {
                 color,
             } => {
                 use crate::entities::traits::EntityTypeOps;
-                use crate::modules::insert::solid3d_cmds::empty_solid3d;
                 use crate::scene::acad_to_truck::TruckObject;
                 use crate::scene::truck_tess;
                 use truck_modeling::builder;
@@ -1415,12 +1392,13 @@ impl OpenCADStudio {
                     mesh
                 });
 
-                if let Some(mut mesh) = result {
+                if let Some(mesh) = result {
                     self.push_undo_snapshot(i, "SWEEP");
-                    let new_entity = empty_solid3d();
-                    let new_handle = self.tabs[i].scene.add_entity(new_entity);
-                    mesh.name = format!("{}", new_handle.value());
-                    self.tabs[i].scene.meshes.insert(new_handle, crate::scene::MeshLodSet::from_single(mesh));
+                    // Persist as a Mesh entity so the solid survives save/reload;
+                    // add_entity re-tessellates it into scene.meshes for display.
+                    let woff = self.tabs[i].scene.world_offset;
+                    let entity = crate::scene::mesh_tess::mesh_entity_from_model(&mesh, woff);
+                    self.tabs[i].scene.add_entity(entity);
                     self.tabs[i].dirty = true;
                     self.command_line.push_output("SWEEP: solid created.");
                 } else {
@@ -1435,7 +1413,6 @@ impl OpenCADStudio {
             // ── LOFT ───────────────────────────────────────────────────────
             CmdResult::LoftEntities { handles, color } => {
                 use crate::entities::traits::EntityTypeOps;
-                use crate::modules::insert::solid3d_cmds::empty_solid3d;
                 use crate::scene::acad_to_truck::TruckObject;
                 use crate::scene::truck_tess;
                 use truck_modeling::builder;
@@ -1499,12 +1476,13 @@ impl OpenCADStudio {
                     }
                 })();
 
-                if let Some(mut mesh) = result {
+                if let Some(mesh) = result {
                     self.push_undo_snapshot(i, "LOFT");
-                    let new_entity = empty_solid3d();
-                    let new_handle = self.tabs[i].scene.add_entity(new_entity);
-                    mesh.name = format!("{}", new_handle.value());
-                    self.tabs[i].scene.meshes.insert(new_handle, crate::scene::MeshLodSet::from_single(mesh));
+                    // Persist as a Mesh entity so the solid survives save/reload;
+                    // add_entity re-tessellates it into scene.meshes for display.
+                    let woff = self.tabs[i].scene.world_offset;
+                    let entity = crate::scene::mesh_tess::mesh_entity_from_model(&mesh, woff);
+                    self.tabs[i].scene.add_entity(entity);
                     self.tabs[i].dirty = true;
                     self.command_line.push_output(&format!(
                         "LOFT: solid created from {} profiles.",

--- a/src/app/cmd_result.rs
+++ b/src/app/cmd_result.rs
@@ -329,10 +329,11 @@ impl OpenCADStudio {
                             return Task::none();
                         }
                         if layer.starts_with("__DIMSPACE__") {
+                            // Snapshot before mutating so the change is undoable.
+                            self.push_undo_snapshot(i, "DIMSPACE");
                             if let Some(encoded) = layer.strip_prefix("__DIMSPACE__") {
                                 apply_dimspace(&mut self.tabs[i].scene, encoded);
                             }
-                            self.push_undo_snapshot(i, "DIMSPACE");
                             self.command_line.push_output("DIMSPACE  Spacing adjusted.");
                             self.tabs[i].dirty = true;
                             self.tabs[i].active_cmd = None;
@@ -349,10 +350,11 @@ impl OpenCADStudio {
                             return Task::none();
                         }
                         if layer.starts_with("__MLEADERALIGN__") {
+                            // Snapshot before mutating so the change is undoable.
+                            self.push_undo_snapshot(i, "MLEADERALIGN");
                             if let Some(encoded) = layer.strip_prefix("__MLEADERALIGN__") {
                                 apply_mleader_align(&mut self.tabs[i].scene, encoded);
                             }
-                            self.push_undo_snapshot(i, "MLEADERALIGN");
                             self.command_line
                                 .push_output("MLEADERALIGN  Leaders aligned.");
                             self.tabs[i].dirty = true;
@@ -361,10 +363,12 @@ impl OpenCADStudio {
                             return Task::none();
                         }
                         if layer.starts_with("__MLEADERCOLLECT__") {
+                            // Snapshot before erasing the merged-away leaders, or
+                            // undo restores the already-collapsed state (data loss).
+                            self.push_undo_snapshot(i, "MLEADERCOLLECT");
                             if let Some(encoded) = layer.strip_prefix("__MLEADERCOLLECT__") {
                                 apply_mleader_collect(&mut self.tabs[i].scene, encoded);
                             }
-                            self.push_undo_snapshot(i, "MLEADERCOLLECT");
                             self.command_line
                                 .push_output("MLEADERCOLLECT  Leaders collected.");
                             self.tabs[i].dirty = true;
@@ -839,6 +843,10 @@ impl OpenCADStudio {
             }
             CmdResult::PeditOp { handle, op } => {
                 use crate::modules::home::modify::pedit::apply_pedit;
+                // Snapshot BEFORE mutating so the op is undoable; apply_pedit
+                // edits the entity in place, so a snapshot taken afterward would
+                // capture the already-changed state. Discard it if nothing changed.
+                self.push_undo_snapshot(i, "PEDIT");
                 let changed = self.tabs[i]
                     .scene
                     .document
@@ -846,11 +854,11 @@ impl OpenCADStudio {
                     .map(|e| apply_pedit(e, &op))
                     .unwrap_or(false);
                 if changed {
-                    self.push_undo_snapshot(i, "PEDIT");
                     self.tabs[i].dirty = true;
                     self.command_line.push_output("PEDIT: applied.");
                     self.refresh_properties();
                 } else {
+                    self.tabs[i].history.undo_stack.pop();
                     self.command_line
                         .push_error("PEDIT: operation not applicable to this entity.");
                 }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -5171,6 +5171,11 @@ impl OpenCADStudio {
                 return Task::done(Message::StepExport);
             }
 
+            // ── SVG export ────────────────────────────────────────────────
+            "SVGOUT" | "EXPORTSVG" => {
+                return Task::done(Message::SvgExport);
+            }
+
             // ── Plot Style Editor GUI ─────────────────────────────────────
             "PLOTSTYLEPANEL" | "PLOTSTYLEEDITOR" | "STYLESMANAGER" => {
                 return Task::done(Message::PlotStylePanelOpen);

--- a/src/app/expr_eval.rs
+++ b/src/app/expr_eval.rs
@@ -150,9 +150,9 @@ impl Parser {
         Ok(left)
     }
 
-    // product → power (('*' | '/' | '%') power)*
+    // product → unary (('*' | '/' | '%') unary)*
     fn parse_product(&mut self) -> Result<f64, ()> {
-        let mut left = self.parse_power()?;
+        let mut left = self.parse_unary()?;
         loop {
             let op = match self.peek().cloned() {
                 Some(Token::Star) => Some("*"),
@@ -163,12 +163,12 @@ impl Parser {
             match op {
                 Some("*") => {
                     self.advance();
-                    let right = self.parse_power()?;
+                    let right = self.parse_unary()?;
                     left = left * right;
                 }
                 Some("/") => {
                     self.advance();
-                    let right = self.parse_power()?;
+                    let right = self.parse_unary()?;
                     if right == 0.0 {
                         return Ok(if left > 0.0 { f64::INFINITY } else if left < 0.0 { f64::NEG_INFINITY } else { f64::NAN });
                     }
@@ -176,7 +176,12 @@ impl Parser {
                 }
                 Some("%") => {
                     self.advance();
-                    let right = self.parse_power()?;
+                    let right = self.parse_unary()?;
+                    // Modulo by zero is undefined; leave the expression
+                    // unevaluated rather than emitting "NaN" into a field.
+                    if right == 0.0 {
+                        return Err(());
+                    }
                     left = left % right;
                 }
                 _ => break,
@@ -185,9 +190,12 @@ impl Parser {
         Ok(left)
     }
 
-    // power → unary ('^' unary)?
+    // power → atom ('^' unary)?
+    // Right-associative and the exponent may carry its own sign, so
+    // 2^2^3 = 2^(2^3) = 256 and 2^-1 = 0.5. Unary minus binds looser than
+    // '^' (parse_unary calls parse_power), so -2^2 = -(2^2) = -4.
     fn parse_power(&mut self) -> Result<f64, ()> {
-        let base = self.parse_unary()?;
+        let base = self.parse_atom()?;
         if let Some(Token::Caret) = self.peek() {
             self.advance();
             let exp = self.parse_unary()?;
@@ -196,7 +204,7 @@ impl Parser {
         Ok(base)
     }
 
-    // unary → ('-' | '+') unary | atom
+    // unary → ('-' | '+') unary | power
     fn parse_unary(&mut self) -> Result<f64, ()> {
         if let Some(Token::Minus) = self.peek() {
             self.advance();
@@ -206,7 +214,7 @@ impl Parser {
             self.advance();
             return Ok(self.parse_unary()?);
         }
-        self.parse_atom()
+        self.parse_power()
     }
 
     // atom → NUMBER | NAME | NAME '(' args ')' | 'pi'
@@ -427,6 +435,21 @@ mod tests {
         assert_eq!(eval_to_string("2^3"), "8");
         assert_eq!(eval_to_string("10%3"), "1");
         assert_eq!(eval_to_string("100 * 2 + 50"), "250");
+    }
+
+    #[test]
+    fn power_is_right_associative_below_unary_minus() {
+        assert_eq!(eval_number("2^2^3"), Some(256.0)); // 2^(2^3), not (2^2)^3
+        assert_eq!(eval_number("2^3^2"), Some(512.0)); // 2^(3^2)
+        assert_eq!(eval_number("-2^2"), Some(-4.0)); // -(2^2), unary minus looser than ^
+        assert_eq!(eval_number("2^-1"), Some(0.5)); // signed exponent
+    }
+
+    #[test]
+    fn modulo_by_zero_is_not_nan() {
+        assert_eq!(eval_number("5%0"), None); // undefined → not evaluated
+        assert!(!eval_to_string("5%0").contains("NaN"));
+        assert_eq!(eval_number("10%3"), Some(1.0)); // normal modulo still works
     }
 
     #[test]

--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -46,7 +46,9 @@ impl OpenCADStudio {
         self.tabs[i].scene.populate_images_from_document();
         self.tabs[i].scene.populate_meshes_from_document();
         self.tabs[i].scene.clear_preview_wire();
-        self.tabs[i].scene.images.clear();
+        // NOTE: do not clear scene.images here — populate_images_from_document
+        // above already rebuilt it; clearing wiped every attached raster image
+        // on undo/redo until reload.
         self.tabs[i].active_cmd = None;
         self.tabs[i].snap_result = None;
         self.tabs[i].active_grip = None;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1232,6 +1232,11 @@ pub enum Message {
     StepExport,
     /// Callback after the user picks (or cancels) the STEP save path.
     StepExportPath(Option<std::path::PathBuf>),
+    // ── SVG export ────────────────────────────────────────────────────────
+    /// Trigger SVG export: collect model-space wires and show save dialog.
+    SvgExport,
+    /// Callback after the user picks (or cancels) the SVG save path.
+    SvgExportPath(Option<std::path::PathBuf>),
     // ── OBJ import ────────────────────────────────────────────────────────
     /// Trigger OBJ import: show open-file dialog.
     ObjImport,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1516,6 +1516,7 @@ impl OpenCADStudio {
 use std::path::PathBuf;
 
 pub fn run() -> iced::Result {
+    crate::profiling::init();
     iced::daemon(OpenCADStudio::boot, OpenCADStudio::update, OpenCADStudio::view)
         .subscription(OpenCADStudio::subscription)
         .title(|state: &OpenCADStudio, window_id: window::Id| {

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -477,7 +477,9 @@ impl OpenCADStudio {
             // ── SVG export ────────────────────────────────────────────────
             Message::SvgExport => {
                 let i = self.active_tab;
-                if self.tabs[i].scene.entity_wires().is_empty() {
+                if self.tabs[i].scene.entity_wires().is_empty()
+                    && self.tabs[i].scene.entity_hatches().is_empty()
+                {
                     self.command_line
                         .push_error("SVGOUT: nothing to export in model space.");
                     return Task::none();
@@ -500,10 +502,11 @@ impl OpenCADStudio {
             Message::SvgExportPath(Some(path)) => {
                 let i = self.active_tab;
                 let wires = self.tabs[i].scene.entity_wires();
+                let hatches = self.tabs[i].scene.entity_hatches();
                 // Match the on-screen model background so the (already
-                // bg-adapted) wire colours read correctly in the export.
+                // bg-adapted) wire/hatch colours read correctly in the export.
                 let [br, bg, bb, _] = self.tabs[i].scene.bg_color;
-                let svg = crate::io::svg::build_svg(&wires, Some([br, bg, bb]));
+                let svg = crate::io::svg::build_svg(&wires, &hatches, Some([br, bg, bb]));
                 match std::fs::write(&path, svg) {
                     Ok(()) => self
                         .command_line

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -562,14 +562,12 @@ impl OpenCADStudio {
                             .unwrap_or_else(|| "obj_mesh".into());
                         mesh.name = file_stem.clone();
                         self.push_undo_snapshot(i, "IMPORTOBJ");
-                        use crate::modules::insert::solid3d_cmds::empty_solid3d;
-                        let entity = empty_solid3d();
+                        // Persist as a Mesh entity so the imported geometry survives
+                        // save/reload; add_entity re-tessellates it into scene.meshes.
+                        let woff = self.tabs[i].scene.world_offset;
+                        let entity = crate::scene::mesh_tess::mesh_entity_from_model(&mesh, woff);
                         let handle = self.tabs[i].scene.add_entity(entity);
                         if !handle.is_null() {
-                            self.tabs[i]
-                                .scene
-                                .meshes
-                                .insert(handle, crate::scene::MeshLodSet::from_single(mesh));
                             self.tabs[i].dirty = true;
                             self.command_line.push_output(&format!(
                                 "IMPORTOBJ: imported \"{}\" as mesh.",

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -474,6 +474,49 @@ impl OpenCADStudio {
 
             Message::StlExportPath(None) => Task::none(),
 
+            // ── SVG export ────────────────────────────────────────────────
+            Message::SvgExport => {
+                let i = self.active_tab;
+                if self.tabs[i].scene.entity_wires().is_empty() {
+                    self.command_line
+                        .push_error("SVGOUT: nothing to export in model space.");
+                    return Task::none();
+                }
+                Task::perform(
+                    async {
+                        rfd::AsyncFileDialog::new()
+                            .set_title("Export SVG")
+                            .set_file_name("export.svg")
+                            .add_filter("SVG Files", &["svg"])
+                            .add_filter("All Files", &["*"])
+                            .save_file()
+                            .await
+                            .map(|h| h.path().to_path_buf())
+                    },
+                    Message::SvgExportPath,
+                )
+            }
+
+            Message::SvgExportPath(Some(path)) => {
+                let i = self.active_tab;
+                let wires = self.tabs[i].scene.entity_wires();
+                // Match the on-screen model background so the (already
+                // bg-adapted) wire colours read correctly in the export.
+                let [br, bg, bb, _] = self.tabs[i].scene.bg_color;
+                let svg = crate::io::svg::build_svg(&wires, Some([br, bg, bb]));
+                match std::fs::write(&path, svg) {
+                    Ok(()) => self
+                        .command_line
+                        .push_output(&format!("SVGOUT: exported to \"{}\"", path.display())),
+                    Err(e) => self
+                        .command_line
+                        .push_error(&format!("SVGOUT: write error: {e}")),
+                }
+                Task::none()
+            }
+
+            Message::SvgExportPath(None) => Task::none(),
+
             // ── STEP AP203 export ─────────────────────────────────────────
             Message::StepExport => {
                 let i = self.active_tab;

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -501,12 +501,31 @@ impl OpenCADStudio {
 
             Message::SvgExportPath(Some(path)) => {
                 let i = self.active_tab;
-                let wires = self.tabs[i].scene.entity_wires();
-                let hatches = self.tabs[i].scene.entity_hatches();
-                // Match the on-screen model background so the (already
-                // bg-adapted) wire/hatch colours read correctly in the export.
-                let [br, bg, bb, _] = self.tabs[i].scene.bg_color;
-                let svg = crate::io::svg::build_svg(&wires, &hatches, Some([br, bg, bb]));
+                let scene = &self.tabs[i].scene;
+                let wires = scene.entity_wires();
+                // Paper-space layout → export at the paper sheet size (white
+                // sheet, print-adapted colours, mm lineweights); model space →
+                // auto-fit the drawing on the model background.
+                let svg = match scene.paper_limits() {
+                    Some(((x0, y0), (x1, y1))) => {
+                        let hatches = scene.paper_canvas_hatches();
+                        let wipeouts = scene.paper_canvas_wipeouts();
+                        crate::io::svg::build_svg_sheet(
+                            &wires,
+                            hatches.as_slice(),
+                            wipeouts.as_slice(),
+                            x0,
+                            y0,
+                            x1 - x0,
+                            y1 - y0,
+                        )
+                    }
+                    None => {
+                        let hatches = scene.entity_hatches();
+                        let [br, bg, bb, _] = scene.bg_color;
+                        crate::io::svg::build_svg(&wires, &hatches, Some([br, bg, bb]))
+                    }
+                };
                 match std::fs::write(&path, svg) {
                     Ok(()) => self
                         .command_line

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -181,11 +181,6 @@ pub enum CmdResult {
         /// Translation vector to apply to vertices inside the window.
         delta: Vec3,
     },
-    /// Create a Solid3D placeholder entity + associated MeshModel.
-    /// `mesh_fn` is called with the entity's handle string to build the mesh.
-    CommitSolid3D {
-        mesh_fn: Box<dyn FnOnce(String) -> Option<crate::scene::mesh_model::MeshModel> + Send>,
-    },
     /// Extrude the profile entity `handle` by `height` along Z.
     ExtrudeEntity {
         handle: Handle,

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -2664,5 +2664,74 @@ mod tests {
         assert_eq!(format_engineering(11.999, 2), "1'-0.00\"");
         assert_eq!(format_engineering(18.0, 2), "1'-6.00\"");
     }
+
+    #[test]
+    fn decimal_separator_swap() {
+        assert_eq!(swap_decimal_sep("1.5", 46), "1.5"); // 46='.', no-op
+        assert_eq!(swap_decimal_sep("1.5", 0), "1.5"); // 0 = default '.'
+        assert_eq!(swap_decimal_sep("1.5", 44), "1,5"); // 44=','
+        assert_eq!(swap_decimal_sep("100", 44), "100"); // nothing to swap
+    }
+
+    #[test]
+    fn angular_zero_suppression_bits() {
+        assert_eq!(apply_angular_zero_suppression("45.00", 0), "45.00");
+        assert_eq!(apply_angular_zero_suppression("45.00", 2), "45"); // trailing
+        assert_eq!(apply_angular_zero_suppression("0.50", 1), ".50"); // leading
+        assert_eq!(apply_angular_zero_suppression("0.50", 3), ".5"); // both
+    }
+
+    #[test]
+    fn linear_zero_suppression_bits() {
+        assert_eq!(apply_linear_zero_suppression("1.500", 8), "1.5"); // trailing
+        assert_eq!(apply_linear_zero_suppression("0.5", 4), ".5"); // leading
+        assert_eq!(apply_linear_zero_suppression("0.500", 12), ".5"); // both
+        assert_eq!(apply_linear_zero_suppression("2.000", 8), "2"); // strip to int
+    }
+
+    #[test]
+    fn linear_value_defaults_strip_trailing() {
+        // No style → dec=4, DIMZIN=8 (trailing-zero suppression).
+        assert_eq!(format_linear_value(1.5, None), "1.5");
+        assert_eq!(format_linear_value(2.0, None), "2");
+        assert_eq!(format_linear_value(0.25, None), "0.25");
+    }
+
+    #[test]
+    fn angular_value_units() {
+        use acadrust::tables::DimStyle;
+        // No style → decimal degrees, 2 dp.
+        assert_eq!(format_angular_value(45.0, None), "45.00°");
+
+        let mut s = DimStyle::new("t");
+        s.dimazin = 0;
+        // Gradians: 90° = 100g.
+        s.dimaunit = 2;
+        s.dimadec = 0;
+        assert_eq!(format_angular_value(90.0, Some(&s)), "100g");
+        // Radians: 180° = π.
+        s.dimaunit = 3;
+        s.dimadec = 4;
+        assert_eq!(format_angular_value(180.0, Some(&s)), "3.1416r");
+        // DMS via style.
+        s.dimaunit = 1;
+        s.dimadec = 0;
+        assert_eq!(format_angular_value(30.5, Some(&s)), "30°30'0\"");
+    }
+
+    #[test]
+    fn linear_value_scale_and_separator() {
+        use acadrust::tables::DimStyle;
+        let mut s = DimStyle::new("t");
+        s.dimlunit = 2; // decimal
+        s.dimdec = 2;
+        s.dimzin = 0; // no suppression, so the fixed dp is visible
+        s.dimrnd = 0.0;
+        s.dimlfac = 2.0; // measurement scale
+        s.dimfrac = 0;
+        s.dimdsep = 44; // comma
+        // 1.5 × dimlfac(2) = 3.0 → "3.00" → comma separator.
+        assert_eq!(format_linear_value(1.5, Some(&s)), "3,00");
+    }
 }
 

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -2546,3 +2546,65 @@ fn perp_sign_default() -> f64 {
     1.0
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acadrust::types::Vector3;
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-4
+    }
+
+    #[test]
+    fn rotate_point_quarter_turn() {
+        // (1,0) rotated +90° about the origin → (0,1).
+        let mut p = Vector3::new(1.0, 0.0, 0.0);
+        rotate_point(&mut p, Vec3::new(0.0, 0.0, 0.0), std::f32::consts::FRAC_PI_2);
+        assert!(close(p.x, 0.0) && close(p.y, 1.0));
+        // About a non-origin centre: (2,1) about (1,1) by 90° → (1,2).
+        let mut q = Vector3::new(2.0, 1.0, 0.0);
+        rotate_point(&mut q, Vec3::new(1.0, 1.0, 0.0), std::f32::consts::FRAC_PI_2);
+        assert!(close(q.x, 1.0) && close(q.y, 2.0));
+    }
+
+    #[test]
+    fn scale_point_about_centre() {
+        let mut p = Vector3::new(2.0, 4.0, 6.0);
+        scale_point(&mut p, Vec3::new(0.0, 0.0, 0.0), 0.5);
+        assert!(close(p.x, 1.0) && close(p.y, 2.0) && close(p.z, 3.0));
+        // Scaling about the point itself is a no-op.
+        let mut q = Vector3::new(5.0, 5.0, 5.0);
+        scale_point(&mut q, Vec3::new(5.0, 5.0, 5.0), 3.0);
+        assert!(close(q.x, 5.0) && close(q.y, 5.0) && close(q.z, 5.0));
+    }
+
+    #[test]
+    fn mirror_point_across_x_axis() {
+        // Reflecting (1,1) across the X axis (0,0)->(1,0) → (1,-1).
+        let mut p = Vector3::new(1.0, 1.0, 0.0);
+        mirror_point(&mut p, Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0));
+        assert!(close(p.x, 1.0) && close(p.y, -1.0));
+    }
+
+    #[test]
+    fn architectural_feet_and_inches() {
+        assert_eq!(format_architectural(18.0, 4), "1'-6\"");
+        assert_eq!(format_architectural(30.0, 4), "2'-6\"");
+        assert_eq!(format_architectural(0.0, 4), "0'-0\"");
+        assert_eq!(format_architectural(-18.0, 4), "-1'-6\"");
+        // 6.5" → half-inch fraction appended.
+        assert_eq!(format_architectural(18.5, 4), "1'-6 1/2\"");
+    }
+
+    #[test]
+    fn fractional_reduces_to_lowest_terms() {
+        assert_eq!(fraction_string(0.25, 2), "1/4");
+        assert_eq!(fraction_string(0.5, 2), "1/2");
+        assert_eq!(fraction_string(0.0, 2), "");
+        assert_eq!(format_fractional(2.5, 2), "2 1/2");
+        assert_eq!(format_fractional(0.25, 2), "1/4"); // whole part omitted
+        assert_eq!(format_fractional(3.0, 2), "3"); // no fraction
+        assert_eq!(format_fractional(-2.5, 2), "-2 1/2");
+    }
+}
+

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -2225,19 +2225,33 @@ fn format_with_unit(value: f64, unit: i16, dec: usize, dimfrac: i16) -> String {
 fn format_engineering(inches: f64, dec: usize) -> String {
     let sign = if inches < 0.0 { "-" } else { "" };
     let abs = inches.abs();
-    let feet = (abs / 12.0).trunc();
-    let rem_in = abs - feet * 12.0;
+    let mut feet = (abs / 12.0).trunc();
+    let mut rem_in = abs - feet * 12.0;
+    // Round inches to the display precision, then carry 12" → 1' so that
+    // 11.999" at 2 dp prints 1'-0.00" rather than 0'-12.00".
+    let factor = 10f64.powi(dec as i32);
+    rem_in = (rem_in * factor).round() / factor;
+    if rem_in >= 12.0 {
+        rem_in -= 12.0;
+        feet += 1.0;
+    }
     format!("{}{:.0}'-{:.*}\"", sign, feet, dec, rem_in)
 }
 
 fn format_architectural(inches: f64, dimfrac: i16) -> String {
     let sign = if inches < 0.0 { "-" } else { "" };
     let abs = inches.abs();
-    let feet = (abs / 12.0).trunc();
+    let mut feet = (abs / 12.0).trunc();
     let rem_in_total = abs - feet * 12.0;
-    let whole = rem_in_total.trunc();
-    let frac = rem_in_total - whole;
-    let frac_str = fraction_string(frac, dimfrac);
+    let mut whole = rem_in_total.trunc();
+    let (carry, frac_str) = round_fraction(rem_in_total - whole, dimfrac);
+    // A fraction that rounds up to a whole inch carries into inches, which may
+    // in turn carry into feet (e.g. 11.99" → 1'-0" not 0'-12").
+    whole += carry as f64;
+    if whole >= 12.0 {
+        whole -= 12.0;
+        feet += 1.0;
+    }
     if frac_str.is_empty() {
         format!("{}{:.0}'-{:.0}\"", sign, feet, whole)
     } else {
@@ -2248,9 +2262,9 @@ fn format_architectural(inches: f64, dimfrac: i16) -> String {
 fn format_fractional(value: f64, dimfrac: i16) -> String {
     let sign = if value < 0.0 { "-" } else { "" };
     let abs = value.abs();
-    let whole = abs.trunc();
-    let frac = abs - whole;
-    let frac_str = fraction_string(frac, dimfrac);
+    let mut whole = abs.trunc();
+    let (carry, frac_str) = round_fraction(abs - whole, dimfrac);
+    whole += carry as f64;
     if frac_str.is_empty() {
         format!("{}{:.0}", sign, whole)
     } else if whole == 0.0 {
@@ -2260,7 +2274,14 @@ fn format_fractional(value: f64, dimfrac: i16) -> String {
     }
 }
 
-fn fraction_string(frac: f64, dimfrac: i16) -> String {
+/// Round `frac` ∈ [0, 1) to the nearest 1/2^k (`k` from DIMFRAC) and reduce.
+/// Returns `(carry, frac_str)`: `carry == 1` when the value rounds up to a
+/// whole unit (the caller must add it to the whole part), and `frac_str` is
+/// the reduced "n/d" — empty when it rounds to 0 or carries to a whole.
+// `% 2 == 0` (not `is_multiple_of`) keeps the crate's stated Rust 1.75+ MSRV;
+// `u64::is_multiple_of` only stabilised in 1.87.
+#[allow(clippy::manual_is_multiple_of)]
+fn round_fraction(frac: f64, dimfrac: i16) -> (i64, String) {
     // DIMFRAC denominator: AutoCAD encodes this on DIMSTYLE via DIMLUNIT
     // pairing — the value we accept is the *power-of-2* exponent (1..=6 ish).
     // Pick a sensible cap so the printed fraction stays readable.
@@ -2268,7 +2289,10 @@ fn fraction_string(frac: f64, dimfrac: i16) -> String {
     let denom = 1u64 << exp;
     let numer = (frac * denom as f64).round() as i64;
     if numer <= 0 {
-        return String::new();
+        return (0, String::new());
+    }
+    if numer as u64 >= denom {
+        return (1, String::new()); // rounded up to a whole unit
     }
     let mut n = numer as u64;
     let mut d = denom;
@@ -2276,13 +2300,7 @@ fn fraction_string(frac: f64, dimfrac: i16) -> String {
         n /= 2;
         d /= 2;
     }
-    if n == 0 {
-        String::new()
-    } else if d == 1 {
-        format!("{}", n) // whole-number overflow back to caller
-    } else {
-        format!("{}/{}", n, d)
-    }
+    (0, format!("{}/{}", n, d))
 }
 
 /// Format an angular measurement (input in degrees as Dimension::measurement
@@ -2319,11 +2337,23 @@ fn format_angular_value(measurement_deg: f64, style: Option<&DimStyle>) -> Strin
 fn format_dms(deg: f64, sec_dec: usize, azin: i16) -> String {
     let sign = if deg < 0.0 { "-" } else { "" };
     let abs = deg.abs();
-    let d = abs.floor();
+    let mut d = abs.floor();
     let m_full = (abs - d) * 60.0;
-    let m = m_full.floor();
+    let mut m = m_full.floor();
     let s = (m_full - m) * 60.0;
-    let s_str = format!("{:.*}", sec_dec, s);
+    // Round seconds to the display precision, then carry 60" → 1', 60' → 1°.
+    // Without the carry, 0.99999° prints "0°59'60"" instead of "1°0'0"".
+    let factor = 10f64.powi(sec_dec as i32);
+    let mut s_rounded = (s * factor).round() / factor;
+    if s_rounded >= 60.0 {
+        s_rounded -= 60.0;
+        m += 1.0;
+        if m >= 60.0 {
+            m -= 60.0;
+            d += 1.0;
+        }
+    }
+    let s_str = format!("{:.*}", sec_dec, s_rounded);
     let mut out = format!("{}{:.0}°{:.0}'{}\"", sign, d, m, s_str);
     if azin & 4 != 0 {
         // suppress 0° / 0' parts
@@ -2598,13 +2628,41 @@ mod tests {
 
     #[test]
     fn fractional_reduces_to_lowest_terms() {
-        assert_eq!(fraction_string(0.25, 2), "1/4");
-        assert_eq!(fraction_string(0.5, 2), "1/2");
-        assert_eq!(fraction_string(0.0, 2), "");
+        assert_eq!(round_fraction(0.25, 2), (0, "1/4".to_string()));
+        assert_eq!(round_fraction(0.5, 2), (0, "1/2".to_string()));
+        assert_eq!(round_fraction(0.0, 2), (0, String::new()));
         assert_eq!(format_fractional(2.5, 2), "2 1/2");
         assert_eq!(format_fractional(0.25, 2), "1/4"); // whole part omitted
         assert_eq!(format_fractional(3.0, 2), "3"); // no fraction
         assert_eq!(format_fractional(-2.5, 2), "-2 1/2");
+    }
+
+    #[test]
+    fn round_fraction_carries_to_whole() {
+        // A value that rounds up to the whole unit reports a carry, no fraction.
+        assert_eq!(round_fraction(0.999, 2), (1, String::new()));
+        // …and the callers must apply that carry rather than print "n 1".
+        assert_eq!(format_fractional(6.999, 2), "7");
+        assert_eq!(format_architectural(6.999, 2), "0'-7\"");
+        // Carry that ripples inches → feet.
+        assert_eq!(format_architectural(11.999, 2), "1'-0\"");
+    }
+
+    #[test]
+    fn dms_seconds_carry() {
+        // 0.99999° must not print "0°59'60"".
+        assert_eq!(format_dms(0.99999, 0, 0), "1°0'0\"");
+        // A clean angle is unaffected.
+        assert_eq!(format_dms(30.5, 0, 0), "30°30'0\"");
+        // Negative sign preserved.
+        assert_eq!(format_dms(-0.99999, 0, 0), "-1°0'0\"");
+    }
+
+    #[test]
+    fn engineering_inches_carry() {
+        // 11.999" at 2 dp must carry to 1'-0.00", not 0'-12.00".
+        assert_eq!(format_engineering(11.999, 2), "1'-0.00\"");
+        assert_eq!(format_engineering(18.0, 2), "1'-6.00\"");
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,6 +9,7 @@ pub mod plot_style;
 pub mod print_to_printer;
 pub mod step;
 pub mod stl;
+pub mod svg;
 pub mod xref;
 
 use crate::scene::DerivedCaches;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -63,14 +63,23 @@ pub async fn open_path_with_phase(
         use std::time::Instant;
         phase2.store(PHASE_PARSING, Ordering::Relaxed);
         let t_parse = Instant::now();
-        let mut doc = load_file(&path2)?;
+        let mut doc = {
+            crate::profile_scope!("io::parse");
+            load_file(&path2)?
+        };
         let parse_ms = t_parse.elapsed().as_millis() as u32;
         let t_purge = Instant::now();
-        let dropped = purge_corrupt_entities(&mut doc);
+        let dropped = {
+            crate::profile_scope!("io::purge");
+            purge_corrupt_entities(&mut doc)
+        };
         let purge_ms = t_purge.elapsed().as_millis() as u32;
         phase2.store(PHASE_CACHING, Ordering::Relaxed);
         let t_caches = Instant::now();
-        let mut caches = crate::scene::build_derived_caches(&doc);
+        let mut caches = {
+            crate::profile_scope!("io::caches");
+            crate::scene::build_derived_caches(&doc)
+        };
         caches.timings = crate::scene::OpenTimings {
             parse_ms,
             purge_ms,

--- a/src/io/svg.rs
+++ b/src/io/svg.rs
@@ -1,0 +1,182 @@
+// SVG export — model-space wires → a standalone SVG document.
+//
+// The 2D drafting view is already tessellated into `WireModel` polyline strips
+// (curves flattened, `NaN` triples separating sub-strokes), so an SVG export is
+// a direct mapping: one `<polyline>` per sub-stroke, coloured by the wire's RGB.
+// The drawing is fit to a `viewBox` over its bounding box. SVG's Y axis points
+// down while CAD's points up, so we mirror Y about the box to keep the drawing
+// upright. Colours are taken as-is from the (background-adapted) wires, so the
+// export is WYSIWYG against the supplied `background`.
+
+use std::fmt::Write as _;
+
+use crate::scene::wire_model::WireModel;
+
+/// Build a standalone SVG document from model-space wires. `background` is an
+/// optional page fill as RGB in [0, 1]; `None` leaves the page transparent.
+/// Returns a minimal empty-canvas SVG when there is no finite geometry.
+pub fn build_svg(wires: &[WireModel], background: Option<[f32; 3]>) -> String {
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+    for w in wires {
+        for &[x, y, _] in &w.points {
+            if x.is_finite() && y.is_finite() {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+            }
+        }
+    }
+    if !min_x.is_finite() {
+        // No finite geometry at all.
+        return String::from(r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>"#);
+    }
+
+    // Pad so edge strokes aren't clipped; handle a zero-extent axis (a single
+    // straight line, or a point) by falling back to a unit pad.
+    let span = (max_x - min_x).max(max_y - min_y);
+    let pad = if span > 1e-9 { span * 0.05 } else { 1.0 };
+    min_x -= pad;
+    min_y -= pad;
+    max_x += pad;
+    max_y += pad;
+    let vw = max_x - min_x;
+    let vh = max_y - min_y;
+    // world y → (min_y + max_y) - y keeps the drawing upright under SVG's
+    // Y-down axis while staying inside the same viewBox.
+    let flip = min_y + max_y;
+    // Hairline stroke in world units, scaled to the drawing so it reads at any
+    // size (there is no device DPI at export time).
+    let stroke_w = (vw.hypot(vh) * 0.0015).max(1e-6);
+
+    let mut s = String::new();
+    let _ = write!(
+        s,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{min_x:.3} {min_y:.3} {vw:.3} {vh:.3}">"#
+    );
+    if let Some([r, g, b]) = background {
+        let _ = write!(
+            s,
+            r#"<rect x="{min_x:.3}" y="{min_y:.3}" width="{vw:.3}" height="{vh:.3}" fill="{}"/>"#,
+            rgb_hex(r, g, b)
+        );
+    }
+    for wire in wires {
+        let [r, g, b, _a] = wire.color;
+        let color = rgb_hex(r, g, b);
+        // `points` is one flat strip; NaN triples split it into sub-strokes.
+        for stroke in wire.points.split(|p| p[0].is_nan() || p[1].is_nan()) {
+            if stroke.len() < 2 {
+                continue;
+            }
+            let mut pts = String::new();
+            for &[x, y, _] in stroke {
+                let _ = write!(pts, "{x:.3},{:.3} ", flip - y);
+            }
+            let _ = write!(
+                s,
+                r#"<polyline points="{}" fill="none" stroke="{color}" stroke-width="{stroke_w:.4}" stroke-linecap="round" stroke-linejoin="round"/>"#,
+                pts.trim_end()
+            );
+        }
+    }
+    s.push_str("</svg>");
+    s
+}
+
+fn rgb_hex(r: f32, g: f32, b: f32) -> String {
+    let c = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    format!("#{:02x}{:02x}{:02x}", c(r), c(g), c(b))
+}
+
+// ── Autocomplete registry ─────────────────────────────────
+inventory::submit!(crate::command::CommandRegistration { names: &["SVGOUT", "EXPORTSVG"] });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire(points: Vec<[f32; 3]>, color: [f32; 4]) -> WireModel {
+        WireModel::solid("w".to_string(), points, color, false)
+    }
+
+    fn count(hay: &str, needle: &str) -> usize {
+        hay.matches(needle).count()
+    }
+
+    #[test]
+    fn empty_input_is_empty_canvas() {
+        let svg = build_svg(&[], None);
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.contains(r#"viewBox="0 0 1 1""#));
+        assert_eq!(count(&svg, "<polyline"), 0);
+    }
+
+    #[test]
+    fn single_line_emits_one_polyline_within_viewbox() {
+        let svg = build_svg(
+            &[wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            None,
+        );
+        assert_eq!(count(&svg, "<polyline"), 1);
+        // A horizontal line has zero-height bbox; padding must still give a
+        // finite viewBox and both endpoints.
+        assert!(svg.contains("0.000,0.000"));
+        assert!(svg.contains("10.000,0.000"));
+        assert!(svg.ends_with("</svg>"));
+    }
+
+    #[test]
+    fn y_axis_is_flipped_upright() {
+        // Vertical world line (0,0)→(0,10): the top (y=10) maps to the top of
+        // the SVG viewBox (small svg-y), i.e. y is mirrored about the bbox.
+        let svg = build_svg(
+            &[wire(vec![[0.0, 0.0, 0.0], [0.0, 10.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            None,
+        );
+        // world y=0 → svg y=10 ; world y=10 → svg y=0.
+        assert!(svg.contains("0.000,10.000"));
+        assert!(svg.contains("0.000,0.000"));
+    }
+
+    #[test]
+    fn color_becomes_hex_stroke() {
+        let svg = build_svg(
+            &[wire(vec![[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]], [1.0, 0.0, 0.0, 1.0])],
+            None,
+        );
+        assert!(svg.contains(r##"stroke="#ff0000""##));
+    }
+
+    #[test]
+    fn nan_splits_into_separate_polylines() {
+        let nan = f32::NAN;
+        let svg = build_svg(
+            &[wire(
+                vec![
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [nan, nan, nan],
+                    [2.0, 0.0, 0.0],
+                    [3.0, 0.0, 0.0],
+                ],
+                [0.0, 0.0, 0.0, 1.0],
+            )],
+            None,
+        );
+        assert_eq!(count(&svg, "<polyline"), 2);
+    }
+
+    #[test]
+    fn background_emits_a_filled_rect() {
+        let svg = build_svg(
+            &[wire(vec![[0.0, 0.0, 0.0], [10.0, 10.0, 0.0]], [1.0, 1.0, 1.0, 1.0])],
+            Some([0.0, 0.0, 0.0]),
+        );
+        assert!(svg.contains("<rect"));
+        assert!(svg.contains(r##"fill="#000000""##));
+    }
+}

--- a/src/io/svg.rs
+++ b/src/io/svg.rs
@@ -1,21 +1,29 @@
-// SVG export — model-space wires → a standalone SVG document.
+// SVG export — model-space wires and hatch fills → a standalone SVG document.
 //
 // The 2D drafting view is already tessellated into `WireModel` polyline strips
-// (curves flattened, `NaN` triples separating sub-strokes), so an SVG export is
-// a direct mapping: one `<polyline>` per sub-stroke, coloured by the wire's RGB.
-// The drawing is fit to a `viewBox` over its bounding box. SVG's Y axis points
+// (curves flattened, `NaN` triples separating sub-strokes) and `HatchModel`
+// fills, so an SVG export is a direct mapping: one `<polyline>` per wire
+// sub-stroke and, per hatch, either a filled `<path>` (solid / gradient) or
+// pattern `<line>`s (hatch patterns), coloured by the model's RGB. Everything
+// is fit to a `viewBox` over the combined bounding box. SVG's Y axis points
 // down while CAD's points up, so we mirror Y about the box to keep the drawing
-// upright. Colours are taken as-is from the (background-adapted) wires, so the
+// upright. Colours are taken as-is from the (background-adapted) models, so the
 // export is WYSIWYG against the supplied `background`.
 
 use std::fmt::Write as _;
 
+use crate::scene::hatch_model::HatchModel;
 use crate::scene::wire_model::WireModel;
 
-/// Build a standalone SVG document from model-space wires. `background` is an
-/// optional page fill as RGB in [0, 1]; `None` leaves the page transparent.
-/// Returns a minimal empty-canvas SVG when there is no finite geometry.
-pub fn build_svg(wires: &[WireModel], background: Option<[f32; 3]>) -> String {
+/// Build a standalone SVG document from model-space wires and hatches.
+/// `background` is an optional page fill as RGB in [0, 1]; `None` leaves the
+/// page transparent. Returns a minimal empty-canvas SVG when there is no finite
+/// geometry.
+pub fn build_svg(
+    wires: &[WireModel],
+    hatches: &[HatchModel],
+    background: Option<[f32; 3]>,
+) -> String {
     let mut min_x = f32::INFINITY;
     let mut min_y = f32::INFINITY;
     let mut max_x = f32::NEG_INFINITY;
@@ -23,6 +31,18 @@ pub fn build_svg(wires: &[WireModel], background: Option<[f32; 3]>) -> String {
     for w in wires {
         for &[x, y, _] in &w.points {
             if x.is_finite() && y.is_finite() {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+            }
+        }
+    }
+    for h in hatches {
+        let (ox, oy) = (h.world_origin[0] as f32, h.world_origin[1] as f32);
+        for &[vx, vy] in h.boundary.iter() {
+            if vx.is_finite() && vy.is_finite() {
+                let (x, y) = (ox + vx, oy + vy);
                 min_x = min_x.min(x);
                 min_y = min_y.min(y);
                 max_x = max_x.max(x);
@@ -64,6 +84,62 @@ pub fn build_svg(wires: &[WireModel], background: Option<[f32; 3]>) -> String {
             rgb_hex(r, g, b)
         );
     }
+
+    // Hatches first, so wires draw on top of their fills (matching render order).
+    for h in hatches {
+        let [r, g, b, _a] = h.color;
+        let color = rgb_hex(r, g, b);
+        let segs = h.pattern_segments();
+        if !segs.is_empty() {
+            // Pattern hatch: the family lines (already in WCS-relative coords).
+            for [a, b_pt] in segs {
+                let _ = write!(
+                    s,
+                    r#"<line x1="{:.3}" y1="{:.3}" x2="{:.3}" y2="{:.3}" stroke="{color}" stroke-width="{stroke_w:.4}"/>"#,
+                    a[0],
+                    flip - a[1],
+                    b_pt[0],
+                    flip - b_pt[1]
+                );
+            }
+        } else {
+            // Solid / gradient: fill the boundary rings (NaN-separated), with
+            // even-odd fill so islands / holes cut out correctly.
+            let (ox, oy) = (h.world_origin[0] as f32, h.world_origin[1] as f32);
+            let mut d = String::new();
+            let mut ring_len = 0usize;
+            let mut started = false;
+            for &[vx, vy] in h.boundary.iter() {
+                if vx.is_nan() || vy.is_nan() {
+                    if ring_len >= 3 {
+                        d.push_str("Z ");
+                    }
+                    started = false;
+                    ring_len = 0;
+                    continue;
+                }
+                let (x, y) = (ox + vx, flip - (oy + vy));
+                if started {
+                    let _ = write!(d, "L{x:.3},{y:.3} ");
+                } else {
+                    let _ = write!(d, "M{x:.3},{y:.3} ");
+                    started = true;
+                }
+                ring_len += 1;
+            }
+            if ring_len >= 3 {
+                d.push_str("Z ");
+            }
+            if !d.is_empty() {
+                let _ = write!(
+                    s,
+                    r#"<path d="{}" fill="{color}" fill-rule="evenodd" stroke="none"/>"#,
+                    d.trim_end()
+                );
+            }
+        }
+    }
+
     for wire in wires {
         let [r, g, b, _a] = wire.color;
         let color = rgb_hex(r, g, b);
@@ -98,9 +174,25 @@ inventory::submit!(crate::command::CommandRegistration { names: &["SVGOUT", "EXP
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scene::hatch_model::{HatchModel, HatchPattern};
+    use std::sync::Arc;
 
     fn wire(points: Vec<[f32; 3]>, color: [f32; 4]) -> WireModel {
         WireModel::solid("w".to_string(), points, color, false)
+    }
+
+    fn solid_hatch(origin: [f64; 2], boundary: Vec<[f32; 2]>, color: [f32; 4]) -> HatchModel {
+        HatchModel {
+            world_origin: origin,
+            boundary: Arc::new(boundary),
+            pattern: HatchPattern::Solid,
+            name: "SOLID".into(),
+            color,
+            angle_offset: 0.0,
+            scale: 1.0,
+            vp_scissor: None,
+            draw_depth: 0.0,
+        }
     }
 
     fn count(hay: &str, needle: &str) -> usize {
@@ -109,21 +201,21 @@ mod tests {
 
     #[test]
     fn empty_input_is_empty_canvas() {
-        let svg = build_svg(&[], None);
+        let svg = build_svg(&[], &[], None);
         assert!(svg.starts_with("<svg"));
         assert!(svg.contains(r#"viewBox="0 0 1 1""#));
         assert_eq!(count(&svg, "<polyline"), 0);
+        assert_eq!(count(&svg, "<path"), 0);
     }
 
     #[test]
     fn single_line_emits_one_polyline_within_viewbox() {
         let svg = build_svg(
             &[wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            &[],
             None,
         );
         assert_eq!(count(&svg, "<polyline"), 1);
-        // A horizontal line has zero-height bbox; padding must still give a
-        // finite viewBox and both endpoints.
         assert!(svg.contains("0.000,0.000"));
         assert!(svg.contains("10.000,0.000"));
         assert!(svg.ends_with("</svg>"));
@@ -131,13 +223,11 @@ mod tests {
 
     #[test]
     fn y_axis_is_flipped_upright() {
-        // Vertical world line (0,0)→(0,10): the top (y=10) maps to the top of
-        // the SVG viewBox (small svg-y), i.e. y is mirrored about the bbox.
         let svg = build_svg(
             &[wire(vec![[0.0, 0.0, 0.0], [0.0, 10.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            &[],
             None,
         );
-        // world y=0 → svg y=10 ; world y=10 → svg y=0.
         assert!(svg.contains("0.000,10.000"));
         assert!(svg.contains("0.000,0.000"));
     }
@@ -146,6 +236,7 @@ mod tests {
     fn color_becomes_hex_stroke() {
         let svg = build_svg(
             &[wire(vec![[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]], [1.0, 0.0, 0.0, 1.0])],
+            &[],
             None,
         );
         assert!(svg.contains(r##"stroke="#ff0000""##));
@@ -165,6 +256,7 @@ mod tests {
                 ],
                 [0.0, 0.0, 0.0, 1.0],
             )],
+            &[],
             None,
         );
         assert_eq!(count(&svg, "<polyline"), 2);
@@ -174,9 +266,41 @@ mod tests {
     fn background_emits_a_filled_rect() {
         let svg = build_svg(
             &[wire(vec![[0.0, 0.0, 0.0], [10.0, 10.0, 0.0]], [1.0, 1.0, 1.0, 1.0])],
+            &[],
             Some([0.0, 0.0, 0.0]),
         );
         assert!(svg.contains("<rect"));
         assert!(svg.contains(r##"fill="#000000""##));
+    }
+
+    #[test]
+    fn solid_hatch_becomes_filled_path() {
+        let h = solid_hatch(
+            [0.0, 0.0],
+            vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]],
+            [1.0, 0.0, 0.0, 1.0],
+        );
+        let svg = build_svg(&[], &[h], None);
+        assert_eq!(count(&svg, "<path"), 1);
+        assert!(svg.contains(r##"fill="#ff0000""##));
+        assert!(svg.contains(r#"fill-rule="evenodd""#));
+        // Closed ring: M … L … Z.
+        assert!(svg.contains("M0.000,") && svg.contains('Z'));
+    }
+
+    #[test]
+    fn hatch_expands_the_viewbox_and_flips() {
+        // A hatch alone must drive the viewBox; its top edge (y=10) maps to the
+        // top of the box (flipped), and world_origin offsets the vertices.
+        let h = solid_hatch(
+            [100.0, 200.0],
+            vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]],
+            [0.5, 0.5, 0.5, 1.0],
+        );
+        let svg = build_svg(&[], &[h], None);
+        assert!(svg.contains("<path"));
+        // Vertex (100+10, 200+10) present with Y mirrored — appears as 110.000
+        // in x and the flipped y (min_y+max_y - 210).
+        assert!(svg.contains("110.000,"));
     }
 }

--- a/src/io/svg.rs
+++ b/src/io/svg.rs
@@ -68,9 +68,11 @@ pub fn build_svg(
     // world y → (min_y + max_y) - y keeps the drawing upright under SVG's
     // Y-down axis while staying inside the same viewBox.
     let flip = min_y + max_y;
-    // Hairline stroke in world units, scaled to the drawing so it reads at any
-    // size (there is no device DPI at export time).
-    let stroke_w = (vw.hypot(vh) * 0.0015).max(1e-6);
+    // Base hairline in world units, scaled to the drawing so it reads at any
+    // size (there is no device DPI at export time). Per-wire widths multiply
+    // this by the entity's resolved lineweight so heavy lines (walls) export
+    // thicker than thin ones (dimensions), matching the on-screen weighting.
+    let base_sw = (vw.hypot(vh) * 0.0015).max(1e-6);
 
     let mut s = String::new();
     let _ = write!(
@@ -95,7 +97,7 @@ pub fn build_svg(
             for [a, b_pt] in segs {
                 let _ = write!(
                     s,
-                    r#"<line x1="{:.3}" y1="{:.3}" x2="{:.3}" y2="{:.3}" stroke="{color}" stroke-width="{stroke_w:.4}"/>"#,
+                    r#"<line x1="{:.3}" y1="{:.3}" x2="{:.3}" y2="{:.3}" stroke="{color}" stroke-width="{base_sw:.4}"/>"#,
                     a[0],
                     flip - a[1],
                     b_pt[0],
@@ -143,6 +145,10 @@ pub fn build_svg(
     for wire in wires {
         let [r, g, b, _a] = wire.color;
         let color = rgb_hex(r, g, b);
+        // Resolved lineweight (screen px, always ≥ 1.0 from render_style) scales
+        // the hairline; clamped to ≥ 1× so a default-weight line keeps the base
+        // width and heavier lines get proportionally thicker.
+        let sw = base_sw * wire.line_weight_px.max(1.0);
         // `points` is one flat strip; NaN triples split it into sub-strokes.
         for stroke in wire.points.split(|p| p[0].is_nan() || p[1].is_nan()) {
             if stroke.len() < 2 {
@@ -154,7 +160,7 @@ pub fn build_svg(
             }
             let _ = write!(
                 s,
-                r#"<polyline points="{}" fill="none" stroke="{color}" stroke-width="{stroke_w:.4}" stroke-linecap="round" stroke-linejoin="round"/>"#,
+                r#"<polyline points="{}" fill="none" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round" stroke-linejoin="round"/>"#,
                 pts.trim_end()
             );
         }
@@ -271,6 +277,27 @@ mod tests {
         );
         assert!(svg.contains("<rect"));
         assert!(svg.contains(r##"fill="#000000""##));
+    }
+
+    fn stroke_width_of(svg: &str) -> f32 {
+        let key = "stroke-width=\"";
+        let i = svg.find(key).expect("a stroke-width") + key.len();
+        let rest = &svg[i..];
+        let end = rest.find('"').unwrap();
+        rest[..end].parse().unwrap()
+    }
+
+    #[test]
+    fn stroke_width_scales_with_lineweight() {
+        // Same geometry (so the base hairline is identical) at two lineweights;
+        // a 3× resolved weight must yield a 3× stroke width.
+        let mut thin = wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0]);
+        thin.line_weight_px = 1.0;
+        let mut thick = wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0]);
+        thick.line_weight_px = 3.0;
+        let wt = stroke_width_of(&build_svg(&[thin], &[], None));
+        let wk = stroke_width_of(&build_svg(&[thick], &[], None));
+        assert!((wk / wt - 3.0).abs() < 0.02, "thin {wt} thick {wk}");
     }
 
     #[test]

--- a/src/io/svg.rs
+++ b/src/io/svg.rs
@@ -1,24 +1,28 @@
-// SVG export — model-space wires and hatch fills → a standalone SVG document.
+// SVG export — model-space and paper-space (layout) → standalone SVG.
 //
-// The 2D drafting view is already tessellated into `WireModel` polyline strips
-// (curves flattened, `NaN` triples separating sub-strokes) and `HatchModel`
-// fills, so an SVG export is a direct mapping: one `<polyline>` per wire
-// sub-stroke and, per hatch, either a filled `<path>` (solid / gradient) or
-// pattern `<line>`s (hatch patterns), coloured by the model's RGB. Everything
-// is fit to a `viewBox` over the combined bounding box. SVG's Y axis points
-// down while CAD's points up, so we mirror Y about the box to keep the drawing
-// upright. Colours are taken as-is from the (background-adapted) models, so the
-// export is WYSIWYG against the supplied `background`.
+// Two entry points share the same emit helpers:
+//   * `build_svg`       — model space: the drawing auto-fit to a viewBox over
+//                         its own bounding box, on the model background.
+//   * `build_svg_sheet` — a paper-space layout: fixed to the paper rectangle
+//                         (white sheet), colours adapted for white paper and
+//                         lineweights in millimetres, matching the PDF plot.
+//
+// The 2D view is already tessellated into `WireModel` polyline strips (curves
+// flattened, `NaN` triples separating sub-strokes) and `HatchModel` fills, so
+// export is a direct mapping to `<polyline>` / `<path>` / `<line>`. SVG's Y
+// axis points down while CAD's points up, so Y is mirrored about the box.
 
 use std::fmt::Write as _;
 
 use crate::scene::hatch_model::HatchModel;
 use crate::scene::wire_model::WireModel;
 
-/// Build a standalone SVG document from model-space wires and hatches.
-/// `background` is an optional page fill as RGB in [0, 1]; `None` leaves the
-/// page transparent. Returns a minimal empty-canvas SVG when there is no finite
-/// geometry.
+/// Screen px → millimetres (inverse of render_style's 96-dpi mm→px).
+const PX_TO_MM: f32 = 25.4 / 96.0;
+
+/// Build a standalone SVG from model-space wires and hatches, auto-fit to the
+/// geometry's bounding box. `background` is an optional page fill in [0, 1].
+/// Returns a minimal empty-canvas SVG when there is no finite geometry.
 pub fn build_svg(
     wires: &[WireModel],
     hatches: &[HatchModel],
@@ -51,12 +55,9 @@ pub fn build_svg(
         }
     }
     if !min_x.is_finite() {
-        // No finite geometry at all.
         return String::from(r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>"#);
     }
 
-    // Pad so edge strokes aren't clipped; handle a zero-extent axis (a single
-    // straight line, or a point) by falling back to a unit pad.
     let span = (max_x - min_x).max(max_y - min_y);
     let pad = if span > 1e-9 { span * 0.05 } else { 1.0 };
     min_x -= pad;
@@ -65,113 +66,169 @@ pub fn build_svg(
     max_y += pad;
     let vw = max_x - min_x;
     let vh = max_y - min_y;
-    // world y → (min_y + max_y) - y keeps the drawing upright under SVG's
-    // Y-down axis while staying inside the same viewBox.
     let flip = min_y + max_y;
-    // Base hairline in world units, scaled to the drawing so it reads at any
-    // size (there is no device DPI at export time). Per-wire widths multiply
-    // this by the entity's resolved lineweight so heavy lines (walls) export
-    // thicker than thin ones (dimensions), matching the on-screen weighting.
     let base_sw = (vw.hypot(vh) * 0.0015).max(1e-6);
 
-    let mut s = String::new();
-    let _ = write!(
-        s,
-        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{min_x:.3} {min_y:.3} {vw:.3} {vh:.3}">"#
-    );
+    let mut s = header(min_x, min_y, vw, vh);
     if let Some([r, g, b]) = background {
-        let _ = write!(
-            s,
-            r#"<rect x="{min_x:.3}" y="{min_y:.3}" width="{vw:.3}" height="{vh:.3}" fill="{}"/>"#,
-            rgb_hex(r, g, b)
-        );
+        rect(&mut s, min_x, min_y, vw, vh, &rgb_hex(r, g, b));
     }
-
-    // Hatches first, so wires draw on top of their fills (matching render order).
     for h in hatches {
-        let [r, g, b, _a] = h.color;
-        let color = rgb_hex(r, g, b);
-        let segs = h.pattern_segments();
-        if !segs.is_empty() {
-            // Pattern hatch: the family lines (already in WCS-relative coords).
-            for [a, b_pt] in segs {
-                let _ = write!(
-                    s,
-                    r#"<line x1="{:.3}" y1="{:.3}" x2="{:.3}" y2="{:.3}" stroke="{color}" stroke-width="{base_sw:.4}"/>"#,
-                    a[0],
-                    flip - a[1],
-                    b_pt[0],
-                    flip - b_pt[1]
-                );
-            }
-        } else {
-            // Solid / gradient: fill the boundary rings (NaN-separated), with
-            // even-odd fill so islands / holes cut out correctly.
-            let (ox, oy) = (h.world_origin[0] as f32, h.world_origin[1] as f32);
-            let mut d = String::new();
-            let mut ring_len = 0usize;
-            let mut started = false;
-            for &[vx, vy] in h.boundary.iter() {
-                if vx.is_nan() || vy.is_nan() {
-                    if ring_len >= 3 {
-                        d.push_str("Z ");
-                    }
-                    started = false;
-                    ring_len = 0;
-                    continue;
-                }
-                let (x, y) = (ox + vx, flip - (oy + vy));
-                if started {
-                    let _ = write!(d, "L{x:.3},{y:.3} ");
-                } else {
-                    let _ = write!(d, "M{x:.3},{y:.3} ");
-                    started = true;
-                }
-                ring_len += 1;
-            }
-            if ring_len >= 3 {
-                d.push_str("Z ");
-            }
-            if !d.is_empty() {
-                let _ = write!(
-                    s,
-                    r#"<path d="{}" fill="{color}" fill-rule="evenodd" stroke="none"/>"#,
-                    d.trim_end()
-                );
-            }
-        }
+        emit_hatch(&mut s, h, flip, base_sw);
     }
-
     for wire in wires {
-        let [r, g, b, _a] = wire.color;
-        let color = rgb_hex(r, g, b);
-        // Resolved lineweight (screen px, always ≥ 1.0 from render_style) scales
-        // the hairline; clamped to ≥ 1× so a default-weight line keeps the base
-        // width and heavier lines get proportionally thicker.
+        let color = rgb_hex(wire.color[0], wire.color[1], wire.color[2]);
         let sw = base_sw * wire.line_weight_px.max(1.0);
-        // `points` is one flat strip; NaN triples split it into sub-strokes.
-        for stroke in wire.points.split(|p| p[0].is_nan() || p[1].is_nan()) {
-            if stroke.len() < 2 {
-                continue;
-            }
-            let mut pts = String::new();
-            for &[x, y, _] in stroke {
-                let _ = write!(pts, "{x:.3},{:.3} ", flip - y);
-            }
-            let _ = write!(
-                s,
-                r#"<polyline points="{}" fill="none" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round" stroke-linejoin="round"/>"#,
-                pts.trim_end()
-            );
-        }
+        emit_wire(&mut s, &wire.points, flip, &color, sw);
     }
     s.push_str("</svg>");
     s
 }
 
+/// Build a paper-sheet SVG for a layout: the viewBox is the paper rectangle
+/// `(x0, y0, paper_w, paper_h)` (paper millimetres), drawn on a white sheet.
+/// Colours are adapted for white paper (near-white / yellow → black, cyan →
+/// dark blue, matching the PDF plot) and lineweights are in millimetres.
+/// `wipeouts` are drawn first (masks), then `hatches`, then `wires`.
+pub fn build_svg_sheet(
+    wires: &[WireModel],
+    hatches: &[HatchModel],
+    wipeouts: &[HatchModel],
+    x0: f64,
+    y0: f64,
+    paper_w: f64,
+    paper_h: f64,
+) -> String {
+    let (x0, y0) = (x0 as f32, y0 as f32);
+    let (pw, ph) = (paper_w.max(1.0) as f32, paper_h.max(1.0) as f32);
+    // Mirror Y within [y0, y0+ph]: world y → (y0 + y1) - y, y1 = y0 + ph.
+    let flip = 2.0 * y0 + ph;
+    // Thin default hairline for hatch pattern lines, in mm.
+    let base_sw = 0.15_f32;
+
+    let mut s = header(x0, y0, pw, ph);
+    rect(&mut s, x0, y0, pw, ph, "#ffffff");
+
+    for h in wipeouts.iter().chain(hatches.iter()) {
+        emit_hatch(&mut s, h, flip, base_sw);
+    }
+    for wire in wires {
+        // The white sheet already provides the paper boundary.
+        if wire.name == "__paper_boundary__" {
+            continue;
+        }
+        let [ar, ag, ab] = print_adapt(wire.color);
+        let color = rgb_hex(ar, ag, ab);
+        let sw = (wire.line_weight_px * PX_TO_MM).max(0.13);
+        emit_wire(&mut s, &wire.points, flip, &color, sw);
+    }
+    s.push_str("</svg>");
+    s
+}
+
+// ── shared emit helpers ─────────────────────────────────────────────────────
+
+fn header(min_x: f32, min_y: f32, w: f32, h: f32) -> String {
+    format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{min_x:.3} {min_y:.3} {w:.3} {h:.3}">"#
+    )
+}
+
+fn rect(s: &mut String, x: f32, y: f32, w: f32, h: f32, fill: &str) {
+    let _ = write!(
+        s,
+        r#"<rect x="{x:.3}" y="{y:.3}" width="{w:.3}" height="{h:.3}" fill="{fill}"/>"#
+    );
+}
+
+/// Emit one wire's sub-strokes (NaN-split) as `<polyline>`s, Y mirrored by `flip`.
+fn emit_wire(s: &mut String, points: &[[f32; 3]], flip: f32, color: &str, sw: f32) {
+    for stroke in points.split(|p| p[0].is_nan() || p[1].is_nan()) {
+        if stroke.len() < 2 {
+            continue;
+        }
+        let mut pts = String::new();
+        for &[x, y, _] in stroke {
+            let _ = write!(pts, "{x:.3},{:.3} ", flip - y);
+        }
+        let _ = write!(
+            s,
+            r#"<polyline points="{}" fill="none" stroke="{color}" stroke-width="{sw:.4}" stroke-linecap="round" stroke-linejoin="round"/>"#,
+            pts.trim_end()
+        );
+    }
+}
+
+/// Emit a hatch: pattern lines for pattern fills, else a filled boundary path.
+fn emit_hatch(s: &mut String, h: &HatchModel, flip: f32, base_sw: f32) {
+    let color = rgb_hex(h.color[0], h.color[1], h.color[2]);
+    let segs = h.pattern_segments();
+    if !segs.is_empty() {
+        for [a, b_pt] in segs {
+            let _ = write!(
+                s,
+                r#"<line x1="{:.3}" y1="{:.3}" x2="{:.3}" y2="{:.3}" stroke="{color}" stroke-width="{base_sw:.4}"/>"#,
+                a[0],
+                flip - a[1],
+                b_pt[0],
+                flip - b_pt[1]
+            );
+        }
+        return;
+    }
+    let (ox, oy) = (h.world_origin[0] as f32, h.world_origin[1] as f32);
+    let mut d = String::new();
+    let mut ring_len = 0usize;
+    let mut started = false;
+    for &[vx, vy] in h.boundary.iter() {
+        if vx.is_nan() || vy.is_nan() {
+            if ring_len >= 3 {
+                d.push_str("Z ");
+            }
+            started = false;
+            ring_len = 0;
+            continue;
+        }
+        let (x, y) = (ox + vx, flip - (oy + vy));
+        if started {
+            let _ = write!(d, "L{x:.3},{y:.3} ");
+        } else {
+            let _ = write!(d, "M{x:.3},{y:.3} ");
+            started = true;
+        }
+        ring_len += 1;
+    }
+    if ring_len >= 3 {
+        d.push_str("Z ");
+    }
+    if !d.is_empty() {
+        let _ = write!(
+            s,
+            r#"<path d="{}" fill="{color}" fill-rule="evenodd" stroke="none"/>"#,
+            d.trim_end()
+        );
+    }
+}
+
 fn rgb_hex(r: f32, g: f32, b: f32) -> String {
     let c = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
     format!("#{:02x}{:02x}{:02x}", c(r), c(g), c(b))
+}
+
+/// Adapt an entity colour for a white sheet, matching the PDF plot: near-white
+/// and viewport-yellow become black; cyan (active viewport border) becomes dark
+/// blue; everything else is unchanged.
+fn print_adapt([r, g, b, _a]: [f32; 4]) -> [f32; 3] {
+    let is_light = r > 0.80 && g > 0.80 && b > 0.80;
+    let is_yellow = r > 0.80 && g > 0.70 && b < 0.30;
+    let is_cyan = r < 0.30 && g > 0.70 && b > 0.70;
+    if is_light || is_yellow {
+        [0.0, 0.0, 0.0]
+    } else if is_cyan {
+        [0.0, 0.15, 0.50]
+    } else {
+        [r, g, b]
+    }
 }
 
 // ── Autocomplete registry ─────────────────────────────────
@@ -185,6 +242,10 @@ mod tests {
 
     fn wire(points: Vec<[f32; 3]>, color: [f32; 4]) -> WireModel {
         WireModel::solid("w".to_string(), points, color, false)
+    }
+
+    fn named_wire(name: &str, points: Vec<[f32; 3]>, color: [f32; 4]) -> WireModel {
+        WireModel::solid(name.to_string(), points, color, false)
     }
 
     fn solid_hatch(origin: [f64; 2], boundary: Vec<[f32; 2]>, color: [f32; 4]) -> HatchModel {
@@ -203,6 +264,14 @@ mod tests {
 
     fn count(hay: &str, needle: &str) -> usize {
         hay.matches(needle).count()
+    }
+
+    fn stroke_width_of(svg: &str) -> f32 {
+        let key = "stroke-width=\"";
+        let i = svg.find(key).expect("a stroke-width") + key.len();
+        let rest = &svg[i..];
+        let end = rest.find('"').unwrap();
+        rest[..end].parse().unwrap()
     }
 
     #[test]
@@ -279,18 +348,8 @@ mod tests {
         assert!(svg.contains(r##"fill="#000000""##));
     }
 
-    fn stroke_width_of(svg: &str) -> f32 {
-        let key = "stroke-width=\"";
-        let i = svg.find(key).expect("a stroke-width") + key.len();
-        let rest = &svg[i..];
-        let end = rest.find('"').unwrap();
-        rest[..end].parse().unwrap()
-    }
-
     #[test]
     fn stroke_width_scales_with_lineweight() {
-        // Same geometry (so the base hairline is identical) at two lineweights;
-        // a 3× resolved weight must yield a 3× stroke width.
         let mut thin = wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0]);
         thin.line_weight_px = 1.0;
         let mut thick = wire(vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], [0.0, 0.0, 0.0, 1.0]);
@@ -311,14 +370,11 @@ mod tests {
         assert_eq!(count(&svg, "<path"), 1);
         assert!(svg.contains(r##"fill="#ff0000""##));
         assert!(svg.contains(r#"fill-rule="evenodd""#));
-        // Closed ring: M … L … Z.
         assert!(svg.contains("M0.000,") && svg.contains('Z'));
     }
 
     #[test]
     fn hatch_expands_the_viewbox_and_flips() {
-        // A hatch alone must drive the viewBox; its top edge (y=10) maps to the
-        // top of the box (flipped), and world_origin offsets the vertices.
         let h = solid_hatch(
             [100.0, 200.0],
             vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]],
@@ -326,8 +382,73 @@ mod tests {
         );
         let svg = build_svg(&[], &[h], None);
         assert!(svg.contains("<path"));
-        // Vertex (100+10, 200+10) present with Y mirrored — appears as 110.000
-        // in x and the flipped y (min_y+max_y - 210).
         assert!(svg.contains("110.000,"));
+    }
+
+    // ── paper sheet ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn sheet_uses_paper_viewbox_and_white_background() {
+        let svg = build_svg_sheet(
+            &[wire(vec![[10.0, 10.0, 0.0], [287.0, 10.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            &[],
+            &[],
+            0.0,
+            0.0,
+            297.0,
+            210.0,
+        );
+        assert!(svg.contains(r#"viewBox="0.000 0.000 297.000 210.000""#));
+        assert!(svg.contains("<rect") && svg.contains(r##"fill="#ffffff""##));
+    }
+
+    #[test]
+    fn sheet_flips_y_within_the_paper() {
+        // A wire on the paper's bottom edge (y=0) maps to the sheet bottom
+        // (svg y = paper height); the top edge (y=210) maps to svg y=0.
+        let svg = build_svg_sheet(
+            &[wire(vec![[0.0, 0.0, 0.0], [0.0, 210.0, 0.0]], [0.0, 0.0, 0.0, 1.0])],
+            &[],
+            &[],
+            0.0,
+            0.0,
+            297.0,
+            210.0,
+        );
+        assert!(svg.contains("0.000,210.000"));
+        assert!(svg.contains("0.000,0.000"));
+    }
+
+    #[test]
+    fn sheet_adapts_white_lines_to_black() {
+        // White model lines would vanish on white paper — they print black.
+        let svg = build_svg_sheet(
+            &[wire(vec![[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]], [1.0, 1.0, 1.0, 1.0])],
+            &[],
+            &[],
+            0.0,
+            0.0,
+            297.0,
+            210.0,
+        );
+        assert!(svg.contains(r##"stroke="#000000""##));
+    }
+
+    #[test]
+    fn sheet_skips_paper_boundary_wire() {
+        let svg = build_svg_sheet(
+            &[named_wire(
+                "__paper_boundary__",
+                vec![[0.0, 0.0, 0.0], [297.0, 0.0, 0.0], [297.0, 210.0, 0.0]],
+                [0.0, 0.0, 0.0, 1.0],
+            )],
+            &[],
+            &[],
+            0.0,
+            0.0,
+            297.0,
+            210.0,
+        );
+        assert_eq!(count(&svg, "<polyline"), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod io;
 pub mod linetypes;
 pub mod modules;
 pub mod patterns;
+pub mod profiling;
 pub mod scene;
 pub mod snap;
 pub mod ui;

--- a/src/linetypes.rs
+++ b/src/linetypes.rs
@@ -424,3 +424,53 @@ fn push_lt_segment(token: &str, out: &mut Vec<LtSegment>) {
         out.push(seg);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_pattern_variants() {
+        assert_eq!(extract_pattern("Dashed __ __ __"), "__ __ __");
+        assert_eq!(extract_pattern("Dot . . . ."), ". . . .");
+        assert_eq!(extract_pattern("Solid"), "Solid");
+    }
+
+    #[test]
+    fn parse_elements_signs_and_dot() {
+        // Positive → dash, negative → space (stored negative), 0 → dot.
+        let els = parse_elements("0.5,-0.25,0");
+        assert_eq!(els.len(), 3);
+        assert!(els[0].is_dash() && (els[0].length - 0.5).abs() < 1e-9);
+        assert!(els[1].is_space() && (els[1].length + 0.25).abs() < 1e-9);
+        assert!(els[2].is_dot());
+    }
+
+    #[test]
+    fn parse_elements_skips_complex_bracket() {
+        // The embedded [ ... ] shape/text element is skipped by the simple
+        // parser, leaving just the two dash/space lengths around it.
+        let els = parse_elements(r#"0.5,["HW",STANDARD,S=0.1],-0.25"#);
+        assert_eq!(els.len(), 2);
+        assert!(els[0].is_dash());
+        assert!(els[1].is_space());
+    }
+
+    #[test]
+    fn parse_builds_linetype_from_lin() {
+        let src = "\
+;; comment
+*DASHED,Dashed __ __ __
+A,0.5,-0.25
+";
+        let lts = parse(src);
+        assert_eq!(lts.len(), 1);
+        let lt = &lts[0];
+        assert_eq!(lt.name, "DASHED");
+        assert_eq!(lt.description, "Dashed __ __ __");
+        assert_eq!(lt.elements.len(), 2);
+        assert!(lt.elements[0].is_dash() && lt.elements[1].is_space());
+        // pattern_length is the sum of absolute element lengths.
+        assert!((lt.pattern_length - 0.75).abs() < 1e-9);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod io;
 mod linetypes;
 mod modules;
 mod patterns;
+mod profiling;
 mod scene;
 mod snap;
 mod ui;

--- a/src/modules/home/modify/fillet.rs
+++ b/src/modules/home/modify/fillet.rs
@@ -1842,3 +1842,107 @@ impl CadCommand for ChamferCommand {
 // ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration { names: &["CHA", "CHAMFER"] });  // ChamferCommand
 inventory::submit!(crate::command::CommandRegistration { names: &["F", "FILLET"] });  // FilletCommand
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn ll_intersects() {
+        // Ray along +X from origin vs ray along +Y from (2, -1) → meet at (2, 0),
+        // i.e. t = 2 along line 1 and u = 1 along line 2.
+        let (t, u) = ll(0.0, 0.0, 1.0, 0.0, 2.0, -1.0, 0.0, 1.0).unwrap();
+        assert!(close(t, 2.0) && close(u, 1.0));
+    }
+
+    #[test]
+    fn ll_parallel_is_none() {
+        assert!(ll(0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0).is_none());
+    }
+
+    #[test]
+    fn project_click_is_signed_distance_along_unit() {
+        assert!(close(project_click([3.0, 4.0], [0.0, 0.0], [1.0, 0.0]), 3.0));
+        assert!(close(project_click([3.0, 4.0], [0.0, 0.0], [0.0, 1.0]), 4.0));
+        // Behind the base point along the unit direction → negative.
+        assert!(close(project_click([-2.0, 0.0], [0.0, 0.0], [1.0, 0.0]), -2.0));
+    }
+
+    #[test]
+    fn norm_angle_wraps() {
+        assert!(close(norm_angle(-FRAC_PI_2), 3.0 * FRAC_PI_2));
+        assert!(close(norm_angle(TAU + 0.5), 0.5));
+    }
+
+    #[test]
+    fn arc_span_ccw() {
+        assert!(close(arc_span(0.0, FRAC_PI_2), FRAC_PI_2));
+        // From π/2 back to 0 the CCW way round is 3π/2.
+        assert!(close(arc_span(FRAC_PI_2, 0.0), 3.0 * FRAC_PI_2));
+        // A zero span is treated as a full circle.
+        assert!(close(arc_span(1.0, 1.0), TAU));
+    }
+
+    #[test]
+    fn arc_angle_at_cardinal_points() {
+        assert!(close(arc_angle_at([0.0, 0.0], [1.0, 0.0]), 0.0));
+        assert!(close(arc_angle_at([0.0, 0.0], [0.0, 1.0]), FRAC_PI_2));
+        assert!(close(arc_angle_at([0.0, 0.0], [-1.0, 0.0]), PI));
+        assert!(close(arc_angle_at([0.0, 0.0], [0.0, -1.0]), 3.0 * FRAC_PI_2));
+    }
+
+    #[test]
+    fn clamp_angle_to_arc_snaps_to_nearer_end() {
+        // Upper-half arc, CCW from 0 to π.
+        assert!(close(clamp_angle_to_arc(FRAC_PI_2, 0.0, PI), FRAC_PI_2)); // inside → unchanged
+        assert!(close(clamp_angle_to_arc(PI + 0.1, 0.0, PI), PI)); // just past the end
+        assert!(close(clamp_angle_to_arc(-0.1, 0.0, PI), 0.0)); // just before the start
+    }
+
+    #[test]
+    fn line_circle_ts_two_one_zero_hits() {
+        // Horizontal line through the centre: two crossings at ±r.
+        let ts = line_circle_ts(-10.0, 0.0, 1.0, 0.0, 0.0, 0.0, 5.0);
+        assert_eq!(ts.len(), 2);
+        assert!(close(ts[0], 5.0) && close(ts[1], 15.0));
+        // Tangent line: a single crossing.
+        let t = line_circle_ts(-10.0, 5.0, 1.0, 0.0, 0.0, 0.0, 5.0);
+        assert_eq!(t.len(), 1);
+        assert!(close(t[0], 10.0));
+        // Miss: no crossing.
+        assert!(line_circle_ts(-10.0, 10.0, 1.0, 0.0, 0.0, 0.0, 5.0).is_empty());
+    }
+
+    #[test]
+    fn circle_circle_pts_two_points() {
+        let pts = circle_circle_pts([0.0, 0.0], 5.0, [8.0, 0.0], 5.0);
+        assert_eq!(pts.len(), 2);
+        // Both lie on circle 1 at x = 4, y = ±3.
+        for p in &pts {
+            assert!(close(p[0], 4.0));
+            assert!(close(p[1].abs(), 3.0));
+            assert!(close(p[0] * p[0] + p[1] * p[1], 25.0));
+        }
+    }
+
+    #[test]
+    fn circle_circle_pts_tangent_and_miss() {
+        // Externally tangent (d == r1 + r2): exactly one point.
+        assert_eq!(circle_circle_pts([0.0, 0.0], 5.0, [10.0, 0.0], 5.0).len(), 1);
+        // Too far apart: none.
+        assert!(circle_circle_pts([0.0, 0.0], 1.0, [10.0, 0.0], 1.0).is_empty());
+    }
+
+    #[test]
+    fn compute_bulge_quarter_circle() {
+        // A 90° CCW arc has bulge tan(90°/4) = tan(22.5°) ≈ 0.41421.
+        let b = compute_bulge([1.0, 0.0], [0.0, 1.0], [0.0, 0.0]);
+        assert!(close(b, (PI / 8.0).tan()));
+        assert!(b > 0.0); // CCW → positive
+    }
+}

--- a/src/modules/home/modify/offset.rs
+++ b/src/modules/home/modify/offset.rs
@@ -718,3 +718,93 @@ impl CadCommand for OffsetCommand {
 
 // ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration { names: &["O", "OFFSET"] });  // OffsetCommand
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn isect_lines_perpendicular() {
+        // The x-axis crossing a vertical line at x = 2 → (2, 0).
+        let p = isect_lines([0.0, 0.0], [1.0, 0.0], [2.0, -1.0], [2.0, 3.0]).unwrap();
+        assert!(close(p[0], 2.0) && close(p[1], 0.0));
+    }
+
+    #[test]
+    fn isect_lines_diagonal() {
+        // y = x  and  y = 2 - x  meet at (1, 1).
+        let p = isect_lines([0.0, 0.0], [1.0, 1.0], [0.0, 2.0], [1.0, 1.0]).unwrap();
+        assert!(close(p[0], 1.0) && close(p[1], 1.0));
+    }
+
+    #[test]
+    fn isect_lines_parallel_is_none() {
+        assert!(isect_lines([0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]).is_none());
+    }
+
+    #[test]
+    fn norm_rad_wraps_into_range() {
+        assert!(close(norm_rad(0.0), 0.0));
+        assert!(close(norm_rad(TAU), 0.0));
+        assert!(close(norm_rad(-std::f64::consts::PI), std::f64::consts::PI));
+        assert!(close(norm_rad(3.0 * TAU + 1.0), 1.0));
+    }
+
+    #[test]
+    fn offset_line_side_determines_direction() {
+        let l = LineEnt::from_coords(0.0, 0.0, 0.0, 10.0, 0.0, 0.0);
+        // Click above the line → the parallel copy shifts +Y.
+        let up = offset_line(&l, 2.0, Vec3::new(5.0, 5.0, 0.0)).unwrap();
+        let EntityType::Line(nl) = up else {
+            panic!("expected a Line")
+        };
+        assert!(close(nl.start.y, 2.0) && close(nl.end.y, 2.0));
+        assert!(close(nl.start.x, 0.0) && close(nl.end.x, 10.0));
+        // Click below → shifts -Y.
+        let down = offset_line(&l, 2.0, Vec3::new(5.0, -5.0, 0.0)).unwrap();
+        let EntityType::Line(nl) = down else {
+            panic!("expected a Line")
+        };
+        assert!(close(nl.start.y, -2.0) && close(nl.end.y, -2.0));
+    }
+
+    #[test]
+    fn offset_line_degenerate_is_none() {
+        let l = LineEnt::from_coords(1.0, 1.0, 0.0, 1.0, 1.0, 0.0);
+        assert!(offset_line(&l, 2.0, Vec3::new(0.0, 0.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn offset_circle_grows_or_shrinks_by_side() {
+        let mut c = CircleEnt::new();
+        c.center.x = 0.0;
+        c.center.y = 0.0;
+        c.radius = 5.0;
+        // Click outside the circle → radius grows by dist.
+        let out = offset_circle(&c, 2.0, Vec3::new(10.0, 0.0, 0.0)).unwrap();
+        let EntityType::Circle(nc) = out else {
+            panic!("expected a Circle")
+        };
+        assert!(close(nc.radius, 7.0));
+        // Click inside → radius shrinks by dist.
+        let inside = offset_circle(&c, 2.0, Vec3::new(1.0, 0.0, 0.0)).unwrap();
+        let EntityType::Circle(nc) = inside else {
+            panic!("expected a Circle")
+        };
+        assert!(close(nc.radius, 3.0));
+    }
+
+    #[test]
+    fn offset_circle_collapsing_is_none() {
+        let mut c = CircleEnt::new();
+        c.center.x = 0.0;
+        c.center.y = 0.0;
+        c.radius = 5.0;
+        // Offsetting inward by the full radius would collapse the circle.
+        assert!(offset_circle(&c, 5.0, Vec3::new(0.5, 0.0, 0.0)).is_none());
+    }
+}

--- a/src/modules/home/modify/trim.rs
+++ b/src/modules/home/modify/trim.rs
@@ -2462,3 +2462,112 @@ impl CadCommand for ExtendCommand {
 // ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration { names: &["EX", "EXTEND"] });  // ExtendCommand
 inventory::submit!(crate::command::CommandRegistration { names: &["TR", "TRIM"] });  // TrimCommand
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn norm_wraps_into_range() {
+        assert!(close(norm(-PI), PI));
+        assert!(close(norm(TAU + 1.0), 1.0));
+        assert!(close(norm(0.0), 0.0));
+    }
+
+    #[test]
+    fn in_arc_simple_upper_half() {
+        // Arc CCW from 0 to π.
+        assert!(in_arc(FRAC_PI_2, 0.0, PI));
+        assert!(!in_arc(3.0 * FRAC_PI_2, 0.0, PI));
+    }
+
+    #[test]
+    fn in_arc_wrapping_across_zero() {
+        // Arc CCW from 3π/2 to π/2 passes through angle 0.
+        assert!(in_arc(0.0, 3.0 * FRAC_PI_2, FRAC_PI_2));
+        assert!(!in_arc(PI, 3.0 * FRAC_PI_2, FRAC_PI_2));
+    }
+
+    #[test]
+    fn in_arc_full_circle() {
+        // Coincident start/end is treated as the whole circle.
+        assert!(in_arc(1.234, 0.0, 0.0));
+    }
+
+    #[test]
+    fn arc_t_parametrises_ccw() {
+        assert!(close(arc_t(0.0, 0.0, FRAC_PI_2), 0.0));
+        assert!(close(arc_t(FRAC_PI_4, 0.0, FRAC_PI_2), 0.5));
+        assert!(close(arc_t(FRAC_PI_2, 0.0, FRAC_PI_2), 1.0));
+        // Beyond the arc end clamps to 1.
+        assert!(close(arc_t(PI, 0.0, FRAC_PI_2), 1.0));
+    }
+
+    #[test]
+    fn ll_intersects_and_parallel() {
+        let (t, u) = ll(0.0, 0.0, 1.0, 0.0, 2.0, -1.0, 0.0, 1.0).unwrap();
+        assert!(close(t, 2.0) && close(u, 1.0));
+        assert!(ll(0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0).is_none());
+    }
+
+    #[test]
+    fn lc_line_circle_hits() {
+        let ts = lc(-10.0, 0.0, 1.0, 0.0, 0.0, 0.0, 5.0);
+        assert_eq!(ts.len(), 2);
+        assert!(close(ts[0], 5.0) && close(ts[1], 15.0));
+        assert!(lc(-10.0, 10.0, 1.0, 0.0, 0.0, 0.0, 5.0).is_empty());
+    }
+
+    #[test]
+    fn cc_angles_two_intersections() {
+        let angs = cc_angles(0.0, 0.0, 5.0, 8.0, 0.0, 5.0);
+        assert_eq!(angs.len(), 2);
+        // Each angle maps back to x = 4, y = ±3 on circle 1.
+        for a in &angs {
+            assert!(close(5.0 * a.cos(), 4.0));
+            assert!(close((5.0 * a.sin()).abs(), 3.0));
+        }
+    }
+
+    #[test]
+    fn cc_angles_disjoint_is_empty() {
+        assert!(cc_angles(0.0, 0.0, 1.0, 10.0, 0.0, 1.0).is_empty());
+    }
+
+    #[test]
+    fn trim_intervals_removes_clicked_span() {
+        // One cut at 0.5; clicking the first half keeps the second half.
+        assert_eq!(trim_intervals(&[0.5], 0.25), vec![(0.5, 1.0)]);
+        // Clicking the second half keeps the first.
+        assert_eq!(trim_intervals(&[0.5], 0.75), vec![(0.0, 0.5)]);
+        // Two cuts; clicking the middle span keeps the two outer spans.
+        assert_eq!(trim_intervals(&[0.3, 0.7], 0.5), vec![(0.0, 0.3), (0.7, 1.0)]);
+        // No cuts → the click removes the whole entity.
+        assert!(trim_intervals(&[], 0.5).is_empty());
+    }
+
+    #[test]
+    fn lerp2_interpolates() {
+        assert_eq!(lerp2([0.0, 0.0], [10.0, 20.0], 0.0), [0.0, 0.0]);
+        assert_eq!(lerp2([0.0, 0.0], [10.0, 20.0], 0.5), [5.0, 10.0]);
+        assert_eq!(lerp2([0.0, 0.0], [10.0, 20.0], 1.0), [10.0, 20.0]);
+    }
+
+    #[test]
+    fn trim_line_keeps_unclicked_segment() {
+        let l = LineEnt::from_coords(0.0, 0.0, 0.0, 10.0, 0.0, 0.0);
+        // Cut at the midpoint (t = 0.5, x = 5) and click the first half.
+        let out = trim_line(&l, &[0.5], 0.25);
+        assert_eq!(out.len(), 1);
+        let EntityType::Line(seg) = &out[0] else {
+            panic!("expected a Line")
+        };
+        assert!(close(seg.start.x, 5.0) && close(seg.end.x, 10.0));
+        assert!(close(seg.start.y, 0.0) && close(seg.end.y, 0.0));
+    }
+}

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -1,12 +1,13 @@
 // 2D→3D modelling commands — EXTRUDE, REVOLVE, SWEEP, LOFT.
 //
 // Each picks profile/path entities and emits a `CmdResult` whose handler
-// builds a truck solid and inserts its MeshModel into scene.meshes under a
-// minimal placeholder Solid3D entity (empty ACIS — saving will not restore
-// the mesh). The standalone primitives (BOX/CYLINDER/CONE/SPHERE/WEDGE/TORUS)
-// live in the Model tab (`modules::model::primitive_cmd`).
+// builds a truck solid, tessellates it, and persists the result as a `Mesh`
+// entity (see `scene::mesh_tess`) — truck B-reps can't be written back as
+// ACIS, but their triangle tessellation round-trips through DWG/DXF as an
+// ACAD_MESH and re-tessellates into a shaded mesh on load. The standalone
+// primitives (BOX/CYLINDER/CONE/SPHERE/WEDGE/TORUS) live in the Model tab
+// (`modules::model::primitive_cmd`).
 
-use acadrust::{entities::Solid3D, EntityType};
 use glam::Vec3;
 
 use crate::command::{CadCommand, CmdResult};
@@ -318,13 +319,6 @@ impl CadCommand for LoftCommand {
             }
         }
     }
-}
-
-// ── Placeholder Solid3D entity construction ────────────────────────────────
-
-/// Create a minimal Solid3D entity with empty ACIS data (placeholder only).
-pub fn empty_solid3d() -> EntityType {
-    EntityType::Solid3D(Solid3D::new())
 }
 
 

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,61 @@
+//! Frame-profiling hooks, gated behind the `profile` cargo feature (Phase 5.1).
+//!
+//! Built with `--features profile`, these forward to [`puffin`] and start a
+//! `puffin_http` server so an external `puffin_viewer` can attach for a live
+//! flamegraph. Without the feature every hook is a zero-cost no-op and neither
+//! puffin nor puffin_http is compiled in, so normal and release builds carry
+//! no profiling dependency or runtime overhead.
+//!
+//! Usage:
+//! - call [`init`] once at startup,
+//! - call [`finish_frame`] at the end of each rendered frame,
+//! - wrap hot scopes with [`crate::profile_scope!`]`("name")`.
+
+#[cfg(feature = "profile")]
+mod imp {
+    use std::sync::OnceLock;
+
+    // Hold the server for the process lifetime; dropping it closes the socket.
+    static SERVER: OnceLock<puffin_http::Server> = OnceLock::new();
+
+    pub fn init() {
+        let addr = format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT);
+        match puffin_http::Server::new(&addr) {
+            Ok(server) => {
+                let _ = SERVER.set(server);
+                puffin::set_scopes_on(true);
+                eprintln!(
+                    "profiling: puffin server on {addr} — attach with \
+                     `puffin_viewer --url 127.0.0.1:{}`",
+                    puffin_http::DEFAULT_PORT
+                );
+            }
+            Err(e) => eprintln!("profiling: could not start puffin server: {e}"),
+        }
+    }
+
+    pub fn finish_frame() {
+        puffin::GlobalProfiler::lock().new_frame();
+    }
+}
+
+#[cfg(not(feature = "profile"))]
+mod imp {
+    #[inline(always)]
+    pub fn init() {}
+    #[inline(always)]
+    pub fn finish_frame() {}
+}
+
+pub use imp::{finish_frame, init};
+
+/// Profile the enclosing scope when the `profile` feature is on; expands to
+/// nothing otherwise. Accepts the same arguments as [`puffin::profile_scope`]
+/// — a static name and an optional dynamic data string.
+#[macro_export]
+macro_rules! profile_scope {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "profile")]
+        ::puffin::profile_scope!($($arg)*);
+    };
+}

--- a/src/scene/complex_lt.rs
+++ b/src/scene/complex_lt.rs
@@ -69,8 +69,10 @@ pub fn apply_along(
         let perp = [-fwd[1], fwd[0], fwd[2]];
 
         let mut pos = 0.0f32;
+        let mut stuck = 0usize;
 
         while pos < seg_len - 1e-6 {
+            let pos_before = pos;
             let idx = elem_idx % scaled.len();
 
             match &scaled[idx] {
@@ -115,9 +117,6 @@ pub fn apply_along(
                     strokes.push(vec![p, p]);
                     elem_idx += 1;
                     elem_consumed = 0.0;
-                    if pos < 1e-6 {
-                        break;
-                    }
                 }
 
                 LtSeg::Shape {
@@ -137,9 +136,6 @@ pub fn apply_along(
 
                     elem_idx += 1;
                     elem_consumed = 0.0;
-                    if pos < 1e-6 {
-                        break;
-                    }
                 }
                 LtSeg::Text {
                     text,
@@ -174,10 +170,21 @@ pub fn apply_along(
 
                     elem_idx += 1;
                     elem_consumed = 0.0;
-                    if pos < 1e-6 {
-                        break;
-                    }
                 }
+            }
+
+            // Zero-length elements (dot / shape / text) advance `elem_idx` but
+            // not `pos`. Bail only if a full pattern cycle passes without any
+            // progress — this avoids an infinite loop without skipping the rest
+            // of the path segment (the old `if pos < 1e-6 { break }` dropped
+            // every dash after a leading dot/shape/text).
+            if pos <= pos_before + 1e-9 {
+                stuck += 1;
+                if stuck > scaled.len() {
+                    break;
+                }
+            } else {
+                stuck = 0;
             }
         }
     }
@@ -331,4 +338,64 @@ fn emit_shape(
                 .collect()
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::linetypes::{ComplexLt, LtSegment};
+
+    fn max_x(wires: &[WireModel]) -> f32 {
+        wires
+            .iter()
+            .flat_map(|w| w.points.iter())
+            .map(|p| p[0])
+            .fold(f32::MIN, f32::max)
+    }
+
+    #[test]
+    fn leading_dot_does_not_drop_the_rest_of_the_segment() {
+        // A pattern starting with a zero-length element (Dot) applied to a
+        // single path segment must still draw the dashes that follow.
+        let lt = ComplexLt {
+            segments: vec![
+                LtSegment::Dot,
+                LtSegment::Dash(5.0),
+                LtSegment::Space(5.0),
+            ],
+        };
+        let path = [[0.0, 0.0, 0.0], [20.0, 0.0, 0.0]];
+        let wires = apply_along("DOTLINE", &path, &lt, 1.0, [0.0, 0.0, 0.0, 1.0], false, 1.0);
+        assert!(
+            max_x(&wires) > 4.0,
+            "dashes after the leading dot were dropped (max_x = {})",
+            max_x(&wires)
+        );
+    }
+
+    #[test]
+    fn plain_dash_space_pattern_is_unchanged() {
+        // Common case must be unaffected: 20 units of [dash 5, space 5] gives
+        // exactly two dashes ([0,5] and [10,15]).
+        let lt = ComplexLt {
+            segments: vec![LtSegment::Dash(5.0), LtSegment::Space(5.0)],
+        };
+        let path = [[0.0, 0.0, 0.0], [20.0, 0.0, 0.0]];
+        let wires = apply_along("DASHED", &path, &lt, 1.0, [0.0, 0.0, 0.0, 1.0], false, 1.0);
+        assert_eq!(wires.len(), 2, "expected two dashes");
+        assert!((max_x(&wires) - 15.0).abs() < 1e-3, "second dash should end at 15");
+    }
+
+    #[test]
+    fn dot_in_pattern_across_vertices_terminates_and_covers() {
+        // A dot mid-pattern over a multi-segment polyline must terminate (no
+        // infinite loop) and still draw dashes on every segment.
+        let lt = ComplexLt {
+            segments: vec![LtSegment::Dash(3.0), LtSegment::Dot, LtSegment::Space(3.0)],
+        };
+        let path = [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0]];
+        let wires = apply_along("DASHDOT", &path, &lt, 1.0, [0.0, 0.0, 0.0, 1.0], false, 1.0);
+        assert!(!wires.is_empty());
+        assert!(max_x(&wires) > 18.0, "dashes should reach the far end (max_x = {})", max_x(&wires));
+    }
 }

--- a/src/scene/image_model.rs
+++ b/src/scene/image_model.rs
@@ -1,20 +1,29 @@
 // ImageModel — CPU-side data for a raster image quad.
 //
-// Holds decoded RGBA pixel data and the world-space quad geometry derived
-// from the RasterImage entity's insertion point, u/v vectors, and pixel size.
+// Holds the world-space quad geometry derived from the RasterImage entity
+// (insertion point, u/v vectors, pixel size) plus a *lazily* decoded RGBA
+// pixel buffer. Decoding is deferred to the first GPU upload (Phase 1.6): an
+// off-screen image whose quad never renders is never decoded, so opening an
+// image-heavy drawing no longer pays the decode + memory cost up front.
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
+/// Decoded RGBA8 pixels plus their true (file) dimensions. Produced on first
+/// access to `ImageModel::decoded`.
 #[derive(Clone, Debug)]
-pub struct ImageModel {
-    /// Original file path (used for reload / display in properties).
-    pub file_path: String,
-    /// RGBA8 pixel data in row-major order. Arc-wrapped so cloning ImageModel
-    /// is O(1) — the pixel bytes are shared, not copied.
+pub struct Decoded {
+    /// RGBA8 pixel data in row-major order. Arc-wrapped so cloning is O(1).
     pub pixels: Arc<Vec<u8>>,
     pub width: u32,
     pub height: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct ImageModel {
+    /// Original file path — used for the deferred decode, reload, and the
+    /// properties panel.
+    pub file_path: String,
     /// Opacity: 1.0 = opaque, 0.0 = transparent.
     pub opacity: f32,
     /// World-space quad corners (CCW), same order as image_corners() helper:
@@ -31,11 +40,18 @@ pub struct ImageModel {
     /// image pipeline as a small clip-z bias so the raster orders correctly
     /// against other entity types.
     pub draw_depth: f32,
+    /// Lazily-decoded pixels. An initialized-but-`None` value means the file
+    /// was missing or undecodable. `Arc<OnceLock>` so every clone of this
+    /// model (e.g. the per-frame `images_arc` snapshot) shares one decode.
+    decoded: Arc<OnceLock<Option<Decoded>>>,
 }
 
 impl ImageModel {
-    /// Build an ImageModel from a DXF RasterImage entity.
-    /// Returns `None` if the image file cannot be opened or decoded.
+    /// Build an ImageModel from a DXF RasterImage entity. The pixel data is
+    /// **not** decoded here — that happens lazily in [`ImageModel::decoded`].
+    /// Always returns `Some`; a bad file path surfaces later as a `None` from
+    /// `decoded()` (the quad simply doesn't render), matching the old
+    /// "excluded on decode failure" behaviour without the up-front decode.
     pub fn from_raster_image(img: &acadrust::entities::RasterImage) -> Option<Self> {
         let w = img.size.x;
         let h = img.size.y;
@@ -56,17 +72,29 @@ impl ImageModel {
         ];
         let opacity = 1.0 - img.fade as f32 / 100.0;
 
-        let (pixels, width, height) = load_pixels(&img.file_path)?;
         Some(Self {
             file_path: img.file_path.clone(),
-            pixels: Arc::new(pixels),
-            width,
-            height,
             opacity,
             corners,
             vp_scissor: None,
             draw_depth: 0.0,
+            decoded: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Decode the pixels on first call and cache the result; later calls — and
+    /// clones sharing the same `Arc<OnceLock>` — reuse it. Returns `None` if
+    /// the file is missing or cannot be decoded.
+    pub fn decoded(&self) -> Option<&Decoded> {
+        self.decoded
+            .get_or_init(|| {
+                load_pixels(&self.file_path).map(|(pixels, width, height)| Decoded {
+                    pixels: Arc::new(pixels),
+                    width,
+                    height,
+                })
+            })
+            .as_ref()
     }
 }
 
@@ -77,4 +105,62 @@ pub fn load_pixels(path_str: &str) -> Option<(Vec<u8>, u32, u32)> {
     let rgba = img.to_rgba8();
     let (w, h) = rgba.dimensions();
     Some((rgba.into_raw(), w, h))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp_png(name: &str, w: u32, h: u32) -> String {
+        let mut path = std::env::temp_dir();
+        path.push(format!("ocs_imgmodel_{}_{}", std::process::id(), name));
+        let buf = image::RgbaImage::from_pixel(w, h, image::Rgba([10, 20, 30, 255]));
+        buf.save(&path).expect("write temp png");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn model_for(path: &str) -> ImageModel {
+        ImageModel {
+            file_path: path.to_string(),
+            opacity: 1.0,
+            corners: [[0.0; 3]; 4],
+            vp_scissor: None,
+            draw_depth: 0.0,
+            decoded: Arc::new(OnceLock::new()),
+        }
+    }
+
+    #[test]
+    fn decode_is_deferred_until_first_access() {
+        let path = write_temp_png("defer.png", 4, 2);
+        let model = model_for(&path);
+        // Nothing decoded yet — construction must not touch the file.
+        assert!(model.decoded.get().is_none());
+
+        let dec = model.decoded().expect("decodes on demand");
+        assert_eq!((dec.width, dec.height), (4, 2));
+        assert_eq!(dec.pixels.len(), 4 * 2 * 4); // w*h*RGBA
+        assert!(model.decoded.get().is_some());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn clones_share_a_single_decode() {
+        let path = write_temp_png("share.png", 2, 2);
+        let a = model_for(&path);
+        let b = a.clone(); // shares the Arc<OnceLock>
+        assert!(a.decoded().is_some());
+        // Deleting the file now must not matter — b reuses a's cached decode.
+        let _ = std::fs::remove_file(&path);
+        assert!(b.decoded.get().is_some());
+        assert!(b.decoded().is_some());
+    }
+
+    #[test]
+    fn missing_file_decodes_to_none() {
+        let model = model_for("/nonexistent/ocs/does-not-exist.png");
+        assert!(model.decoded().is_none());
+        // Result is cached: the cell is now initialized (to None).
+        assert!(model.decoded.get().is_some());
+    }
 }

--- a/src/scene/lff.rs
+++ b/src/scene/lff.rs
@@ -668,6 +668,72 @@ fn bulge_to_points(p0: [f32; 2], p1: [f32; 2], bulge: f32) -> Vec<[f32; 2]> {
 mod tests {
     use super::*;
 
+    // Bounding box [min_x, min_y, max_x, max_y] of a stroke set.
+    fn bbox(strokes: &[Vec<[f32; 2]>]) -> [f32; 4] {
+        let mut b = [f32::INFINITY, f32::INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY];
+        for s in strokes {
+            for &[x, y] in s {
+                b[0] = b[0].min(x);
+                b[1] = b[1].min(y);
+                b[2] = b[2].max(x);
+                b[3] = b[3].max(y);
+            }
+        }
+        b
+    }
+
+    fn run(origin: [f32; 2], rot: f32, wf: f32, text: &str) -> Vec<Vec<[f32; 2]>> {
+        tessellate_text_run(origin, 9.0, rot, wf, 0.0, 1.0, "standard", text)
+    }
+
+    #[test]
+    fn empty_or_zero_height_yields_nothing() {
+        assert!(run([0.0, 0.0], 0.0, 1.0, "").is_empty());
+        assert!(tessellate_text_run([0.0, 0.0], 0.0, 0.0, 1.0, 0.0, 1.0, "standard", "AB").is_empty());
+        assert!(!run([0.0, 0.0], 0.0, 1.0, "AB").is_empty());
+    }
+
+    #[test]
+    fn origin_only_translates() {
+        // The same text at two origins differs by exactly the origin delta at
+        // every point — glyph geometry is reused, only the transform changes.
+        let a = run([0.0, 0.0], 0.0, 1.0, "AB");
+        let b = run([10.0, -5.0], 0.0, 1.0, "AB");
+        assert_eq!(a.len(), b.len());
+        for (sa, sb) in a.iter().zip(&b) {
+            assert_eq!(sa.len(), sb.len());
+            for (&[ax, ay], &[bx, by]) in sa.iter().zip(sb) {
+                assert!((bx - ax - 10.0).abs() < 1e-3, "dx {}", bx - ax);
+                assert!((by - ay + 5.0).abs() < 1e-3, "dy {}", by - ay);
+            }
+        }
+    }
+
+    #[test]
+    fn width_factor_widens_without_changing_height() {
+        let one = bbox(&run([0.0, 0.0], 0.0, 1.0, "MMM"));
+        let two = bbox(&run([0.0, 0.0], 0.0, 2.0, "MMM"));
+        let w1 = one[2] - one[0];
+        let w2 = two[2] - two[0];
+        // A larger width factor widens the run but leaves the cap height alone.
+        // (The exact horizontal scaling law is intentionally not asserted — see
+        // the super-linear cursor/width-factor interaction in tessellate_text_run.)
+        assert!(w2 > w1 * 1.5, "wf=2 should widen: w1 {w1:.2} w2 {w2:.2}");
+        assert!(((two[3] - two[1]) - (one[3] - one[1])).abs() < 1e-2, "height changed");
+    }
+
+    #[test]
+    fn rotation_swaps_extents() {
+        // A wide horizontal run becomes tall when rotated 90°.
+        let flat = bbox(&run([0.0, 0.0], 0.0, 1.0, "WIDE TEXT"));
+        let turned = bbox(&run([0.0, 0.0], std::f32::consts::FRAC_PI_2, 1.0, "WIDE TEXT"));
+        assert!(flat[2] - flat[0] > flat[3] - flat[1], "flat run should be wider than tall");
+        assert!(
+            turned[3] - turned[1] > turned[2] - turned[0],
+            "rotated run should be taller than wide"
+        );
+    }
+
     #[test]
     fn fonts_parse_and_resolve() {
         // Straight-stroke glyph.

--- a/src/scene/lff.rs
+++ b/src/scene/lff.rs
@@ -396,7 +396,7 @@ pub fn tessellate_text_run(
                             None => continue,
                         }
                     } else {
-                        cursor_x += (6.0 + font.letter_spacing * tracking) * wf;
+                        cursor_x += 6.0 + font.letter_spacing * tracking;
                         continue;
                     }
                 }
@@ -424,11 +424,17 @@ pub fn tessellate_text_run(
                     }
                     out.push(stroke.iter().map(|&[gx, gy]| xform(gx, gy, cursor_x)).collect());
                 }
-                cursor_x += (glyph.advance + font.letter_spacing * tracking) * wf;
+                // The cursor advances in glyph units; the width factor is
+                // applied once in `xform` (matching text_support::
+                // text_local_bounds and measure_word). Scaling the advance by
+                // `wf` here too double-applied it to the cursor, spreading
+                // glyphs super-linearly (a 2× factor gave ~3.5× spacing) and
+                // overflowing the width the MText layout allotted.
+                cursor_x += glyph.advance + font.letter_spacing * tracking;
             }
             None => {
                 warn_missing_glyph(font_name, render_ch);
-                cursor_x += (6.0 + font.letter_spacing * tracking) * wf;
+                cursor_x += 6.0 + font.letter_spacing * tracking;
             }
         }
     }
@@ -710,16 +716,35 @@ mod tests {
     }
 
     #[test]
-    fn width_factor_widens_without_changing_height() {
+    fn width_factor_scales_x_linearly() {
         let one = bbox(&run([0.0, 0.0], 0.0, 1.0, "MMM"));
         let two = bbox(&run([0.0, 0.0], 0.0, 2.0, "MMM"));
         let w1 = one[2] - one[0];
         let w2 = two[2] - two[0];
-        // A larger width factor widens the run but leaves the cap height alone.
-        // (The exact horizontal scaling law is intentionally not asserted — see
-        // the super-linear cursor/width-factor interaction in tessellate_text_run.)
-        assert!(w2 > w1 * 1.5, "wf=2 should widen: w1 {w1:.2} w2 {w2:.2}");
+        // The width factor scales the horizontal extent linearly (a 2× factor
+        // → 2× width) and leaves the cap height untouched. A regression here
+        // would mean wf is being applied more than once to the cursor.
+        assert!((w2 / w1 - 2.0).abs() < 0.02, "w1 {w1:.2} w2 {w2:.2}");
         assert!(((two[3] - two[1]) - (one[3] - one[1])).abs() < 1e-2, "height changed");
+    }
+
+    #[test]
+    fn render_width_matches_bounds_path() {
+        // tessellate_text_run (render) and text_local_bounds (measurement /
+        // MText layout) must agree on the horizontal extent for a non-unit
+        // width factor — the two disagreed while the render path double-applied
+        // the width factor.
+        use crate::entities::text_support::text_local_bounds;
+        for &wf in &[0.5, 1.0, 2.0, 3.0] {
+            let rendered = bbox(&run([0.0, 0.0], 0.0, wf, "MMM"));
+            let (bmin, bmax) = text_local_bounds("standard", "MMM", 9.0, wf, 0.0).unwrap();
+            let render_w = rendered[2] - rendered[0];
+            let bounds_w = bmax[0] - bmin[0];
+            assert!(
+                (render_w - bounds_w).abs() < 1e-2,
+                "wf {wf}: render {render_w:.3} vs bounds {bounds_w:.3}"
+            );
+        }
     }
 
     #[test]

--- a/src/scene/mesh_tess.rs
+++ b/src/scene/mesh_tess.rs
@@ -1,0 +1,205 @@
+// Persistable-mesh tessellation: acadrust `Mesh` (ACAD_MESH / AcDbSubDMesh)
+// entity <-> scene `MeshModel`.
+//
+// EXTRUDE / REVOLVE / SWEEP / LOFT build a truck B-rep and tessellate it to a
+// triangle mesh. truck B-reps cannot be written back to DWG/DXF as ACIS, so a
+// solid stored under a placeholder empty `Solid3D` was lost on save/reload.
+// Instead we persist the triangle tessellation as a real `Mesh` entity — both
+// the DWG and DXF writers serialize it (ACAD_MESH / AcDbSubDMesh) and both
+// readers parse it back — and re-tessellate it into a shaded `MeshModel` on
+// load, exactly like the ACIS solid path.
+
+use acadrust::entities::Mesh;
+use acadrust::types::{Color, Vector3};
+use acadrust::EntityType;
+
+use crate::scene::mesh_model::{MeshLodSet, MeshModel};
+
+/// Build a persistable `Mesh` entity from a scene-local `MeshModel`.
+///
+/// `MeshModel` vertices are in local space (WCS − `world_offset`); the offset
+/// is added back so the stored entity carries WCS coordinates, matching every
+/// other document entity. The requested colour is stored as a true colour so
+/// `render_style` resolves the reloaded mesh back to the same look.
+pub fn mesh_entity_from_model(mesh: &MeshModel, world_offset: [f64; 3]) -> EntityType {
+    let [ox, oy, oz] = world_offset;
+    let verts: Vec<Vector3> = mesh
+        .verts
+        .iter()
+        .map(|&[x, y, z]| Vector3::new(x as f64 + ox, y as f64 + oy, z as f64 + oz))
+        .collect();
+    let tris: Vec<(usize, usize, usize)> = mesh
+        .indices
+        .chunks_exact(3)
+        .map(|t| (t[0] as usize, t[1] as usize, t[2] as usize))
+        .collect();
+
+    // `from_triangles` also computes the edge list the writers need.
+    let mut m = Mesh::from_triangles(verts, &tris);
+    let [r, g, b, _] = mesh.color;
+    m.common.color = Color::Rgb {
+        r: (r.clamp(0.0, 1.0) * 255.0).round() as u8,
+        g: (g.clamp(0.0, 1.0) * 255.0).round() as u8,
+        b: (b.clamp(0.0, 1.0) * 255.0).round() as u8,
+    };
+    EntityType::Mesh(m)
+}
+
+/// Tessellate a `Mesh` entity into a WORLD-space single-LOD `MeshLodSet`.
+///
+/// Mirrors the ACIS solid path: the caller subtracts `world_offset` via
+/// `offset_mesh_lod_set`. Faces with more than three vertices are
+/// fan-triangulated; per-vertex normals are area-weighted from the incident
+/// triangles. Returns `None` for a non-`Mesh` entity or one with no geometry.
+pub fn tessellate_mesh_entity(entity: &EntityType, color: [f32; 4]) -> Option<MeshLodSet> {
+    let mesh = match entity {
+        EntityType::Mesh(m) => m,
+        _ => return None,
+    };
+    if mesh.vertices.is_empty() || mesh.faces.is_empty() {
+        return None;
+    }
+
+    let verts: Vec<[f32; 3]> = mesh
+        .vertices
+        .iter()
+        .map(|v| [v.x as f32, v.y as f32, v.z as f32])
+        .collect();
+
+    let mut indices: Vec<u32> = Vec::new();
+    for face in &mesh.faces {
+        let vs = &face.vertices;
+        if vs.len() < 3 {
+            continue;
+        }
+        // Fan-triangulate around the first vertex; skip any face index that
+        // falls outside the vertex list rather than panicking on bad data.
+        for k in 1..vs.len() - 1 {
+            let (a, b, c) = (vs[0], vs[k], vs[k + 1]);
+            if a < verts.len() && b < verts.len() && c < verts.len() {
+                indices.push(a as u32);
+                indices.push(b as u32);
+                indices.push(c as u32);
+            }
+        }
+    }
+    if indices.is_empty() {
+        return None;
+    }
+
+    let normals = compute_vertex_normals(&verts, &indices);
+    let model = MeshModel {
+        name: String::new(),
+        verts,
+        normals,
+        indices,
+        color,
+        selected: false,
+    };
+    Some(MeshLodSet::from_single(model))
+}
+
+/// Area-weighted per-vertex normals from a triangle-indexed mesh. The cross
+/// product magnitude equals twice the triangle area, so larger triangles
+/// contribute proportionally more to each shared vertex.
+fn compute_vertex_normals(verts: &[[f32; 3]], indices: &[u32]) -> Vec<[f32; 3]> {
+    let mut normals = vec![[0.0f32; 3]; verts.len()];
+    for tri in indices.chunks_exact(3) {
+        let (i0, i1, i2) = (tri[0] as usize, tri[1] as usize, tri[2] as usize);
+        let a = verts[i0];
+        let b = verts[i1];
+        let c = verts[i2];
+        let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+        let n = [
+            ab[1] * ac[2] - ab[2] * ac[1],
+            ab[2] * ac[0] - ab[0] * ac[2],
+            ab[0] * ac[1] - ab[1] * ac[0],
+        ];
+        for &idx in &[i0, i1, i2] {
+            normals[idx][0] += n[0];
+            normals[idx][1] += n[1];
+            normals[idx][2] += n[2];
+        }
+    }
+    for n in &mut normals {
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        if len > 1e-12 {
+            n[0] /= len;
+            n[1] /= len;
+            n[2] /= len;
+        } else {
+            *n = [0.0, 0.0, 1.0];
+        }
+    }
+    normals
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit_tri_model() -> MeshModel {
+        MeshModel {
+            name: String::new(),
+            verts: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            normals: vec![],
+            indices: vec![0, 1, 2],
+            color: [0.25, 0.5, 0.75, 1.0],
+            selected: false,
+        }
+    }
+
+    #[test]
+    fn round_trips_geometry_and_offset() {
+        let model = unit_tri_model();
+        // Store with a world offset; the entity must carry WCS coordinates.
+        let entity = mesh_entity_from_model(&model, [10.0, 20.0, 30.0]);
+        let EntityType::Mesh(ref m) = entity else {
+            panic!("expected a Mesh entity")
+        };
+        assert_eq!(m.vertices.len(), 3);
+        assert_eq!(m.faces.len(), 1);
+        assert!((m.vertices[1].x - 11.0).abs() < 1e-6); // 1 + 10
+        assert!((m.vertices[2].y - 21.0).abs() < 1e-6); // 1 + 20
+
+        // Re-tessellate: vertices come back in WCS, ready for offset_mesh_lod_set.
+        let set = tessellate_mesh_entity(&entity, model.color).unwrap();
+        let back = &set.lods[0];
+        assert_eq!(back.indices, vec![0, 1, 2]);
+        assert!((back.verts[1][0] - 11.0).abs() < 1e-4);
+        assert_eq!(back.color, model.color);
+        // A normal was synthesised for every vertex (triangle lies in Z=0 plane).
+        assert_eq!(back.normals.len(), 3);
+        assert!((back.normals[0][2].abs() - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn color_is_stored_as_true_color() {
+        let entity = mesh_entity_from_model(&unit_tri_model(), [0.0, 0.0, 0.0]);
+        let EntityType::Mesh(ref m) = entity else {
+            panic!("expected a Mesh entity")
+        };
+        assert_eq!(m.common.color, Color::Rgb { r: 64, g: 128, b: 191 });
+    }
+
+    #[test]
+    fn quad_face_is_fan_triangulated() {
+        let mut entity = mesh_entity_from_model(&unit_tri_model(), [0.0, 0.0, 0.0]);
+        if let EntityType::Mesh(ref mut m) = entity {
+            m.vertices.push(Vector3::new(1.0, 1.0, 0.0));
+            m.faces.clear();
+            m.faces
+                .push(acadrust::entities::MeshFace::new(vec![0, 1, 3, 2]));
+        }
+        let set = tessellate_mesh_entity(&entity, [1.0, 1.0, 1.0, 1.0]).unwrap();
+        // One quad → two triangles → six indices.
+        assert_eq!(set.lods[0].indices.len(), 6);
+    }
+
+    #[test]
+    fn non_mesh_entity_is_none() {
+        let line = EntityType::Line(acadrust::entities::Line::new());
+        assert!(tessellate_mesh_entity(&line, [1.0, 1.0, 1.0, 1.0]).is_none());
+    }
+}

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1676,6 +1676,7 @@ impl Scene {
         cam_aspect: f32,
         tile_pixel_height: f32,
     ) -> Arc<Vec<WireModel>> {
+        crate::profile_scope!("scene::model_tile_wires");
         let wpp = if tile_pixel_height > 0.0 {
             Some((2.0 * cam.ortho_size()) / tile_pixel_height)
         } else {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1804,6 +1804,12 @@ impl Scene {
         (*self.entity_wires_arc()).clone()
     }
 
+    /// Model-space hatch fills with resolved (background-adapted) colours.
+    /// Mirrors `entity_wires`; used by exporters (e.g. SVG).
+    pub fn entity_hatches(&self) -> Vec<HatchModel> {
+        (*self.hatch_models_arc()).clone()
+    }
+
     /// Per-entity normalized draw-order depth, keyed by entity handle value.
     /// Built (and cached per geometry epoch) by ranking every entity within
     /// its owning block by effective sort key (SortEntitiesTable override or

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -4736,6 +4736,7 @@ impl Scene {
             self.selected.remove(&h);
             self.hatches.remove(&h);
             self.meshes.remove(&h);
+            self.images.remove(&h);
             self.model_solids.remove(&h);
             self.mark_entity_dirty(h);
         }
@@ -4866,6 +4867,52 @@ impl Scene {
 
     // ── Modify (transform / copy) ─────────────────────────────────────────
 
+    /// (Re)build the mesh / image derived-cache entry for `handle` from the
+    /// current document entity. `meshes` and `images` are persistent caches
+    /// keyed by handle that are NOT rebuilt from the document on edit, so a
+    /// copied Mesh/RasterImage would render nothing and a transformed one would
+    /// stay at its old pose without this. Hatches are handled inline by callers.
+    fn rebuild_derived_for(&mut self, handle: Handle) {
+        let Some(entity) = self.document.get_entity(handle).cloned() else {
+            return;
+        };
+        let woff = self.world_offset;
+        match &entity {
+            EntityType::Solid3D(_) | EntityType::Region(_) | EntityType::Body(_) => {
+                let color = self.render_style(&entity).0;
+                let facet_res = self.document.header.facet_resolution;
+                match crate::entities::solid3d::tessellate_volume(&entity, color, facet_res) {
+                    Some(m) => {
+                        self.meshes.insert(handle, offset_mesh_lod_set(m, woff));
+                    }
+                    None => {
+                        self.meshes.remove(&handle);
+                    }
+                }
+            }
+            EntityType::Mesh(_) => {
+                let color = self.render_style(&entity).0;
+                match mesh_tess::tessellate_mesh_entity(&entity, color) {
+                    Some(m) => {
+                        self.meshes.insert(handle, offset_mesh_lod_set(m, woff));
+                    }
+                    None => {
+                        self.meshes.remove(&handle);
+                    }
+                }
+            }
+            EntityType::RasterImage(img) => match ImageModel::from_raster_image(img) {
+                Some(m) => {
+                    self.images.insert(handle, m);
+                }
+                None => {
+                    self.images.remove(&handle);
+                }
+            },
+            _ => {}
+        }
+    }
+
     pub fn transform_entities(&mut self, handles: &[Handle], t: &EntityTransform) {
         let hatch_offset = if self.current_layout == "Model" {
             self.world_offset
@@ -4914,6 +4961,14 @@ impl Scene {
                 if let Some(model) = new_model {
                     self.hatches.insert(h, model);
                 }
+            }
+            // A moved/rotated/scaled Mesh or RasterImage mutates the document
+            // geometry but not its cached MeshLodSet/ImageModel — rebuild them.
+            if matches!(
+                self.document.get_entity(h),
+                Some(EntityType::Mesh(_) | EntityType::RasterImage(_))
+            ) {
+                self.rebuild_derived_for(h);
             }
         }
         if preserve_text_orientation {
@@ -4971,6 +5026,10 @@ impl Scene {
                 if let Some(model) = new_model {
                     self.hatches.insert(h, model);
                 }
+                // Seed mesh/image caches for the copy; without this a copied
+                // Mesh/Solid3D/RasterImage exists in the document but renders
+                // nothing (the caches are keyed by handle, not rebuilt on copy).
+                self.rebuild_derived_for(h);
             }
             new_handles.push(h);
         }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -3418,7 +3418,11 @@ impl Scene {
         if let EntityType::RasterImage(ref mut img) = entity {
             if img.definition_handle.is_none() {
                 use acadrust::objects::{ImageDefinition, ObjectType};
-                let def_handle = Handle::new(self.document.next_handle());
+                // allocate_handle() reserves the id AND advances the counter;
+                // next_handle() only peeks, so the RasterImage added below would
+                // otherwise be given this same id — a duplicate handle that
+                // corrupts the saved DWG/DXF.
+                let def_handle = self.document.allocate_handle();
                 let mut img_def = ImageDefinition::with_dimensions(
                     &img.file_path,
                     img.size.x as u32,

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -10,6 +10,7 @@ pub mod hatch_patterns;
 pub mod hit_test;
 pub mod image_model;
 pub mod mesh_model;
+pub mod mesh_tess;
 pub mod model_solid;
 pub mod object;
 pub mod pipeline;
@@ -185,9 +186,10 @@ pub fn build_derived_caches(doc: &CadDocument) -> DerivedCaches {
         match e {
             EntityType::Hatch(_) | EntityType::Solid(_) => hatch_handles.push(h),
             EntityType::RasterImage(_) => image_handles.push(h),
-            EntityType::Solid3D(_) | EntityType::Region(_) | EntityType::Body(_) => {
-                mesh_handles.push(h)
-            }
+            EntityType::Solid3D(_)
+            | EntityType::Region(_)
+            | EntityType::Body(_)
+            | EntityType::Mesh(_) => mesh_handles.push(h),
             _ => {}
         }
         if let Some(c) = offset_centroid(e, model_block, &prep) {
@@ -246,8 +248,11 @@ pub fn build_derived_caches(doc: &CadDocument) -> DerivedCaches {
             let e = doc.get_entity(handle)?;
             let (raw, ..) = render::render_style_for(doc, e);
             let color = render::adapt_to_bg(raw, LOAD_BG);
-            crate::entities::solid3d::tessellate_volume(e, color, facet_res)
-                .map(|m| (handle, offset_mesh_lod_set(m, world_offset)))
+            let set = match e {
+                EntityType::Mesh(_) => mesh_tess::tessellate_mesh_entity(e, color),
+                _ => crate::entities::solid3d::tessellate_volume(e, color, facet_res),
+            };
+            set.map(|m| (handle, offset_mesh_lod_set(m, world_offset)))
         })
         .collect();
 
@@ -3393,6 +3398,10 @@ impl Scene {
             let woff = self.world_offset;
             crate::entities::solid3d::tessellate_volume(&entity, color, facet_res)
                 .map(|m| offset_mesh_lod_set(m, woff))
+        } else if matches!(&entity, EntityType::Mesh(_)) {
+            let color = self.render_style(&entity).0;
+            let woff = self.world_offset;
+            mesh_tess::tessellate_mesh_entity(&entity, color).map(|m| offset_mesh_lod_set(m, woff))
         } else {
             None
         };
@@ -4254,7 +4263,10 @@ impl Scene {
             .document
             .entities()
             .filter_map(|e| match e {
-                EntityType::Solid3D(_) | EntityType::Region(_) | EntityType::Body(_) => {
+                EntityType::Solid3D(_)
+                | EntityType::Region(_)
+                | EntityType::Body(_)
+                | EntityType::Mesh(_) => {
                     let color = self.render_style(e).0;
                     Some((e.common().handle, e.clone(), color))
                 }
@@ -4268,8 +4280,11 @@ impl Scene {
         self.meshes = entries
             .into_par_iter()
             .filter_map(|(handle, entity, color)| {
-                crate::entities::solid3d::tessellate_volume(&entity, color, facet_res)
-                    .map(|m| (handle, offset_mesh_lod_set(m, woff)))
+                let set = match &entity {
+                    EntityType::Mesh(_) => mesh_tess::tessellate_mesh_entity(&entity, color),
+                    _ => crate::entities::solid3d::tessellate_volume(&entity, color, facet_res),
+                };
+                set.map(|m| (handle, offset_mesh_lod_set(m, woff)))
             })
             .collect();
 

--- a/src/scene/pipeline/image_gpu.rs
+++ b/src/scene/pipeline/image_gpu.rs
@@ -70,7 +70,10 @@ impl ImageGpu {
         model: &ImageModel,
         bgl1: &wgpu::BindGroupLayout,
     ) -> Option<Self> {
-        if model.pixels.is_empty() || model.width == 0 || model.height == 0 {
+        // Decode lazily on first upload (Phase 1.6). An off-screen image whose
+        // quad is culled before it ever reaches here is never decoded.
+        let dec = model.decoded()?;
+        if dec.pixels.is_empty() || dec.width == 0 || dec.height == 0 {
             return None;
         }
 
@@ -79,8 +82,8 @@ impl ImageGpu {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some(&tex_label),
             size: wgpu::Extent3d {
-                width: model.width,
-                height: model.height,
+                width: dec.width,
+                height: dec.height,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
@@ -92,15 +95,15 @@ impl ImageGpu {
         });
         queue.write_texture(
             texture.as_image_copy(),
-            &model.pixels[..],
+            &dec.pixels[..],
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(4 * model.width),
-                rows_per_image: Some(model.height),
+                bytes_per_row: Some(4 * dec.width),
+                rows_per_image: Some(dec.height),
             },
             wgpu::Extent3d {
-                width: model.width,
-                height: model.height,
+                width: dec.width,
+                height: dec.height,
                 depth_or_array_layers: 1,
             },
         );

--- a/src/scene/render.rs
+++ b/src/scene/render.rs
@@ -191,6 +191,7 @@ impl shader::Primitive for Primitive {
         bounds: &Rectangle,
         viewport: &Viewport,
     ) {
+        crate::profile_scope!("pipeline::prepare");
         let phys = viewport.physical_size();
         let full_size = Size::new(phys.width, phys.height);
         let scale = viewport.scale_factor() as f32;
@@ -281,12 +282,15 @@ impl shader::Primitive for Primitive {
             // the resident base wire buffer.
             inner.upload_preview_wires(device, &vp.preview_wires[..], &vp.draw_depths);
             let vproj = vp.uniforms.view_proj;
-            inner.compute_wire_scissors(vproj, clip_size.width, clip_size.height);
-            inner.compute_wipeout_scissors(vproj, clip_size.width, clip_size.height);
-            inner.compute_image_scissors(vproj, clip_size.width, clip_size.height);
-            inner.compute_hatch_lod(queue, vproj, clip_size.width, clip_size.height);
-            inner.compute_wipeout_lod(vproj, clip_size.width, clip_size.height);
-            inner.compute_mesh_lod(vproj, clip_size.width, clip_size.height);
+            {
+                crate::profile_scope!("pipeline::cull");
+                inner.compute_wire_scissors(vproj, clip_size.width, clip_size.height);
+                inner.compute_wipeout_scissors(vproj, clip_size.width, clip_size.height);
+                inner.compute_image_scissors(vproj, clip_size.width, clip_size.height);
+                inner.compute_hatch_lod(queue, vproj, clip_size.width, clip_size.height);
+                inner.compute_wipeout_lod(vproj, clip_size.width, clip_size.height);
+                inner.compute_mesh_lod(vproj, clip_size.width, clip_size.height);
+            }
             if vp.show_viewcube {
                 inner.viewcube.upload(
                     queue,
@@ -306,6 +310,7 @@ impl shader::Primitive for Primitive {
         target: &iced::wgpu::TextureView,
         clip: &Rectangle<u32>,
     ) {
+        crate::profile_scope!("pipeline::render");
         let cw = clip.width as f32;
         let ch = clip.height as f32;
         let clip_right = clip.x + clip.width;
@@ -369,6 +374,10 @@ impl shader::Primitive for Primitive {
                 inner.viewcube.render(encoder, target, vp_clip);
             }
         }
+        // End of the per-frame GPU submission — advance the profiler frame so
+        // puffin segments its timeline here. Harmless (splits into sub-frames)
+        // if multiple viewport widgets render in one real frame.
+        crate::profiling::finish_frame();
     }
 }
 
@@ -564,6 +573,7 @@ impl Scene {
         model_render_mode: acadrust::entities::ViewportRenderMode,
         _hover_region: Option<usize>,
     ) -> Primitive {
+        crate::profile_scope!("scene::build_viewports");
         // Hover comes from the scene cell driven by the app-level
         // `CursorMoved` handler — the cube overlay sits above the shader
         // and would otherwise mask the move event from `Program::update`.

--- a/src/snap/mod.rs
+++ b/src/snap/mod.rs
@@ -758,3 +758,93 @@ fn t_on_segment(p: Point, a: Point, b: Point) -> f32 {
     }
     (((p.x - a.x) * dx + (p.y - a.y) * dy) / len2).clamp(0.0, 1.0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-4
+    }
+    fn v(x: f32, y: f32) -> Vec3 {
+        Vec3::new(x, y, 0.0)
+    }
+
+    #[test]
+    fn nearest_on_segment_clamps_and_projects() {
+        let (p0, p1) = (v(0.0, 0.0), v(10.0, 0.0));
+        // Interior projection.
+        let m = nearest_on_segment(v(5.0, 5.0), p0, p1);
+        assert!(close(m.x, 5.0) && close(m.y, 0.0));
+        // Past the far end → clamped to p1.
+        let e = nearest_on_segment(v(15.0, 5.0), p0, p1);
+        assert!(close(e.x, 10.0) && close(e.y, 0.0));
+        // Before the start → clamped to p0.
+        let s = nearest_on_segment(v(-5.0, 5.0), p0, p1);
+        assert!(close(s.x, 0.0) && close(s.y, 0.0));
+        // Degenerate segment returns p0.
+        let d = nearest_on_segment(v(3.0, 3.0), v(2.0, 2.0), v(2.0, 2.0));
+        assert!(close(d.x, 2.0) && close(d.y, 2.0));
+    }
+
+    #[test]
+    fn nearest_on_segment_interpolates_z() {
+        // t is computed in XY, then applied to Z.
+        let m = nearest_on_segment(v(5.0, 0.0), Vec3::new(0.0, 0.0, 0.0), Vec3::new(10.0, 0.0, 10.0));
+        assert!(close(m.z, 5.0));
+    }
+
+    #[test]
+    fn perp_foot_within_window_only() {
+        let (p0, p1) = (v(0.0, 0.0), v(10.0, 0.0));
+        let f = perp_foot(v(5.0, 5.0), p0, p1).unwrap();
+        assert!(close(f.x, 5.0) && close(f.y, 0.0));
+        // Foot at t = 2.5 (beyond the 2× window) is rejected.
+        assert!(perp_foot(v(5.0, 5.0), v(0.0, 0.0), v(2.0, 0.0)).is_none());
+        // Degenerate segment → None.
+        assert!(perp_foot(v(1.0, 1.0), v(0.0, 0.0), v(0.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn seg_intersect_xy_crossing_parallel_and_disjoint() {
+        // Cross at (5, 0).
+        let p = seg_intersect_xy(v(0.0, 0.0), v(10.0, 0.0), v(5.0, -5.0), v(5.0, 5.0)).unwrap();
+        assert!(close(p.x, 5.0) && close(p.y, 0.0));
+        // Parallel → None.
+        assert!(seg_intersect_xy(v(0.0, 0.0), v(10.0, 0.0), v(0.0, 1.0), v(10.0, 1.0)).is_none());
+        // Would cross only if extended → None (out of range).
+        assert!(seg_intersect_xy(v(0.0, 0.0), v(10.0, 0.0), v(20.0, -5.0), v(20.0, 5.0)).is_none());
+    }
+
+    #[test]
+    fn seg_intersect_2d_returns_params() {
+        let (t, s) = seg_intersect_2d(
+            Point::new(0.0, 0.0),
+            Point::new(10.0, 0.0),
+            Point::new(5.0, -5.0),
+            Point::new(5.0, 5.0),
+        )
+        .unwrap();
+        assert!(close(t, 0.5) && close(s, 0.5));
+    }
+
+    #[test]
+    fn dist2_and_dist2_to_segment() {
+        assert!(close(dist2(Point::new(2.0, 3.0), Point::new(5.0, 7.0)), 25.0));
+        // Perp distance to the interior of the segment.
+        let d = dist2_to_segment(Point::new(5.0, 5.0), Point::new(0.0, 0.0), Point::new(10.0, 0.0));
+        assert!(close(d, 25.0));
+        // Past the end → distance to the endpoint (clamped).
+        let e = dist2_to_segment(Point::new(15.0, 3.0), Point::new(0.0, 0.0), Point::new(10.0, 0.0));
+        assert!(close(e, 34.0)); // (5,3) → 25 + 9
+    }
+
+    #[test]
+    fn t_on_segment_clamps() {
+        assert!(close(t_on_segment(Point::new(5.0, 0.0), Point::new(0.0, 0.0), Point::new(10.0, 0.0)), 0.5));
+        assert!(close(t_on_segment(Point::new(-5.0, 0.0), Point::new(0.0, 0.0), Point::new(10.0, 0.0)), 0.0));
+        assert!(close(t_on_segment(Point::new(50.0, 0.0), Point::new(0.0, 0.0), Point::new(10.0, 0.0)), 1.0));
+        // Degenerate segment → 0.
+        assert!(close(t_on_segment(Point::new(1.0, 1.0), Point::new(0.0, 0.0), Point::new(0.0, 0.0)), 0.0));
+    }
+}

--- a/tests/entity_roundtrip.rs
+++ b/tests/entity_roundtrip.rs
@@ -1,0 +1,148 @@
+// DXF/DWG round-trip coverage for core 2D entities. Builds a document, saves
+// it through the real acadrust writers, reads it back, and asserts the geometry
+// survives — the file I/O every drawing depends on. A field that doesn't
+// round-trip shows up as a failing assertion here rather than as silent data
+// loss in a saved drawing.
+
+use acadrust::entities::{Arc, Circle, Ellipse, Line, LwPolyline, LwVertex, Point, Text};
+use acadrust::types::{Vector2, Vector3};
+use acadrust::{CadDocument, EntityType};
+
+fn sample_doc() -> CadDocument {
+    let mut doc = CadDocument::new();
+
+    doc.add_entity(EntityType::Line(Line::from_coords(1.0, 2.0, 0.0, 8.0, 9.0, 0.0)))
+        .expect("add line");
+
+    doc.add_entity(EntityType::Circle(Circle::from_center_radius(
+        Vector3::new(5.0, 6.0, 0.0),
+        3.5,
+    )))
+    .expect("add circle");
+
+    let mut arc = Arc::new();
+    arc.center = Vector3::new(0.0, 0.0, 0.0);
+    arc.radius = 4.0;
+    arc.start_angle = 0.5;
+    arc.end_angle = 2.0;
+    doc.add_entity(EntityType::Arc(arc)).expect("add arc");
+
+    let mut poly = LwPolyline::new();
+    poly.vertices.push(LwVertex::new(Vector2::new(0.0, 0.0)));
+    let mut mid = LwVertex::new(Vector2::new(10.0, 0.0));
+    mid.bulge = 0.5; // arc segment
+    poly.vertices.push(mid);
+    poly.vertices.push(LwVertex::new(Vector2::new(10.0, 10.0)));
+    poly.is_closed = true;
+    doc.add_entity(EntityType::LwPolyline(poly)).expect("add lwpolyline");
+
+    let mut text = Text::new();
+    text.value = "HELLO".to_string();
+    text.insertion_point = Vector3::new(3.0, 4.0, 0.0);
+    text.height = 2.5;
+    text.rotation = 0.3;
+    doc.add_entity(EntityType::Text(text)).expect("add text");
+
+    let mut ell = Ellipse::from_center_axes(Vector3::new(1.0, 1.0, 0.0), Vector3::new(5.0, 0.0, 0.0), 0.4);
+    ell.start_parameter = 0.0;
+    ell.end_parameter = std::f64::consts::PI;
+    doc.add_entity(EntityType::Ellipse(ell)).expect("add ellipse");
+
+    let mut pt = Point::new();
+    pt.location = Vector3::new(7.0, 8.0, 0.0);
+    doc.add_entity(EntityType::Point(pt)).expect("add point");
+
+    doc
+}
+
+fn round_trip(doc: &CadDocument, ext: &str) -> CadDocument {
+    let mut path = std::env::temp_dir();
+    path.push(format!("ocs_roundtrip_{}.{ext}", std::process::id()));
+    OpenCADStudio::io::save(doc, &path).unwrap_or_else(|e| panic!("save {ext}: {e}"));
+    let back = OpenCADStudio::io::load_file(&path).unwrap_or_else(|e| panic!("load {ext}: {e}"));
+    let _ = std::fs::remove_file(&path);
+    back
+}
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-6
+}
+
+fn assert_geometry_survives(doc: &CadDocument, ext: &str) {
+    let mut seen = [false; 7];
+    for e in doc.entities() {
+        match e {
+            EntityType::Line(l) => {
+                seen[0] = true;
+                assert!(close(l.start.x, 1.0) && close(l.start.y, 2.0), "{ext}: line start");
+                assert!(close(l.end.x, 8.0) && close(l.end.y, 9.0), "{ext}: line end");
+            }
+            EntityType::Circle(c) => {
+                seen[1] = true;
+                assert!(close(c.center.x, 5.0) && close(c.center.y, 6.0), "{ext}: circle center");
+                assert!(close(c.radius, 3.5), "{ext}: circle radius = {}", c.radius);
+            }
+            EntityType::Arc(a) => {
+                seen[2] = true;
+                assert!(close(a.center.x, 0.0) && close(a.center.y, 0.0), "{ext}: arc center");
+                assert!(close(a.radius, 4.0), "{ext}: arc radius = {}", a.radius);
+                assert!(close(a.start_angle, 0.5), "{ext}: arc start = {}", a.start_angle);
+                assert!(close(a.end_angle, 2.0), "{ext}: arc end = {}", a.end_angle);
+            }
+            EntityType::LwPolyline(p) => {
+                seen[3] = true;
+                assert_eq!(p.vertices.len(), 3, "{ext}: lwpolyline vertex count");
+                assert!(p.is_closed, "{ext}: lwpolyline closed flag");
+                assert!(
+                    close(p.vertices[1].location.x, 10.0) && close(p.vertices[1].bulge, 0.5),
+                    "{ext}: lwpolyline vertex/bulge (bulge = {})",
+                    p.vertices[1].bulge
+                );
+            }
+            EntityType::Text(t) => {
+                seen[4] = true;
+                assert_eq!(t.value, "HELLO", "{ext}: text value");
+                assert!(close(t.height, 2.5), "{ext}: text height = {}", t.height);
+                assert!(close(t.rotation, 0.3), "{ext}: text rotation = {}", t.rotation);
+                assert!(
+                    close(t.insertion_point.x, 3.0) && close(t.insertion_point.y, 4.0),
+                    "{ext}: text insertion"
+                );
+            }
+            EntityType::Ellipse(el) => {
+                seen[5] = true;
+                assert!(close(el.center.x, 1.0) && close(el.center.y, 1.0), "{ext}: ellipse center");
+                assert!(close(el.major_axis.x, 5.0), "{ext}: ellipse major axis");
+                assert!(
+                    close(el.minor_axis_ratio, 0.4),
+                    "{ext}: ellipse ratio = {}",
+                    el.minor_axis_ratio
+                );
+            }
+            EntityType::Point(p) => {
+                seen[6] = true;
+                assert!(
+                    close(p.location.x, 7.0) && close(p.location.y, 8.0),
+                    "{ext}: point location"
+                );
+            }
+            _ => {}
+        }
+    }
+    let names = ["line", "circle", "arc", "lwpolyline", "text", "ellipse", "point"];
+    for (ok, name) in seen.iter().zip(names) {
+        assert!(ok, "{ext}: {name} missing after round-trip");
+    }
+}
+
+#[test]
+fn entities_survive_dxf() {
+    let back = round_trip(&sample_doc(), "dxf");
+    assert_geometry_survives(&back, "dxf");
+}
+
+#[test]
+fn entities_survive_dwg() {
+    let back = round_trip(&sample_doc(), "dwg");
+    assert_geometry_survives(&back, "dwg");
+}

--- a/tests/mesh_persistence.rs
+++ b/tests/mesh_persistence.rs
@@ -1,0 +1,91 @@
+// End-to-end persistence check for EXTRUDE/REVOLVE/SWEEP/LOFT/IMPORTOBJ output.
+//
+// Those commands store their truck tessellation as an ACAD_MESH entity (built
+// by `scene::mesh_tess::mesh_entity_from_model`) so the solid survives a
+// save/reload. This test drives the real acadrust writers and readers for both
+// DXF and DWG and asserts the mesh geometry comes back intact — the part the
+// unit tests cannot cover.
+
+use std::path::PathBuf;
+
+use acadrust::{CadDocument, EntityType};
+use OpenCADStudio::scene::mesh_model::MeshModel;
+use OpenCADStudio::scene::mesh_tess::{mesh_entity_from_model, tessellate_mesh_entity};
+
+/// A unit tetrahedron: 4 vertices, 4 triangular faces.
+fn tetrahedron_model() -> MeshModel {
+    MeshModel {
+        name: String::new(),
+        verts: vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        normals: vec![],
+        indices: vec![0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3],
+        color: [0.2, 0.4, 0.8, 1.0],
+        selected: false,
+    }
+}
+
+fn tmp_path(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    // Include the PID so parallel test runs don't collide.
+    p.push(format!("ocs_mesh_persist_{}_{}", std::process::id(), name));
+    p
+}
+
+/// Save a document containing one Mesh entity, reload it, and return the first
+/// Mesh entity found — proving the writer + reader round-trip the geometry.
+fn round_trip(ext: &str) -> (usize, [f64; 3]) {
+    let model = tetrahedron_model();
+    // Store with a non-zero world offset, exactly as the command handlers do.
+    let world_offset = [100.0, 200.0, 0.0];
+    let entity = mesh_entity_from_model(&model, world_offset);
+
+    let mut doc = CadDocument::new();
+    doc.add_entity(entity).expect("add mesh entity");
+
+    let path = tmp_path(&format!("mesh.{ext}"));
+    OpenCADStudio::io::save(&doc, &path).unwrap_or_else(|e| panic!("save {ext}: {e}"));
+
+    let doc2 =
+        OpenCADStudio::io::load_file(&path).unwrap_or_else(|e| panic!("load {ext}: {e}"));
+    let _ = std::fs::remove_file(&path);
+
+    let mesh_entity = doc2
+        .entities()
+        .find(|e| matches!(e, EntityType::Mesh(_)))
+        .unwrap_or_else(|| panic!("no Mesh entity after {ext} round-trip"));
+
+    // The reloaded entity must still tessellate into a renderable mesh.
+    let set = tessellate_mesh_entity(mesh_entity, model.color)
+        .unwrap_or_else(|| panic!("reloaded {ext} mesh did not tessellate"));
+    let lod = &set.lods[0];
+    assert_eq!(lod.indices.len(), 12, "{ext}: expected 4 triangles");
+
+    // Report vertex count and the WCS position of the vertex that was (1,0,0)
+    // locally → (101, 200, 0) in WCS.
+    if let EntityType::Mesh(m) = mesh_entity {
+        (m.vertices.len(), [m.vertices[1].x, m.vertices[1].y, m.vertices[1].z])
+    } else {
+        unreachable!()
+    }
+}
+
+#[test]
+fn mesh_survives_dxf_round_trip() {
+    let (nverts, v1) = round_trip("dxf");
+    assert_eq!(nverts, 4, "dxf: vertex count");
+    assert!((v1[0] - 101.0).abs() < 1e-4, "dxf: vertex X = {}", v1[0]);
+    assert!((v1[1] - 200.0).abs() < 1e-4, "dxf: vertex Y = {}", v1[1]);
+}
+
+#[test]
+fn mesh_survives_dwg_round_trip() {
+    let (nverts, v1) = round_trip("dwg");
+    assert_eq!(nverts, 4, "dwg: vertex count");
+    assert!((v1[0] - 101.0).abs() < 1e-4, "dwg: vertex X = {}", v1[0]);
+    assert!((v1[1] - 200.0).abs() < 1e-4, "dwg: vertex Y = {}", v1[1]);
+}


### PR DESCRIPTION
## Description
A set of fixes, tests, and one new feature developed on the mf4633 fork and verified green (test suite grown 38 → 101). Two are user-visible correctness bugs in text and dimension rendering; one adds SVG export; the rest cover persistence, performance, CI, and test coverage. Everything was verified headlessly (build + tests + clippy, and an actual SVG render); GUI paths were exercised only where drivable without a display, so a quick interactive smoke-test is worthwhile.
## Type of change
- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Tests / CI / tooling
- [ ] Breaking change
## Changes
Each group is independent and could instead be taken as its own PR:
### 1. Bug fixes
- **Text width factor applied twice.** `lff::tessellate_text_run` multiplied the glyph advance by the width factor and then multiplied the cursor by it again (wf^2), so a 2x factor spread glyphs ~3.5x and over-ran the width MTEXT layout allotted. Now the cursor advances in glyph units and wf is applied once, matching `text_local_bounds` / `measure_word`.
- **Dimension formatters dropped rounding carries:**
  | Input | Was | Now |
  |-------|-----|-----|
  | `format_dms(0.99999deg)` | `0d59'60"` | `1d0'0"` |
  | `format_engineering(11.999")` @2dp | `0'-12.00"` | `1'-0.00"` |
  | `format_architectural(6.999")` | `0'-6 1"` | `0'-7"` |
  Each component is rounded then carried (sec->min->deg, in->ft, frac->in->ft).
### 2. SVG export (SVGOUT / EXPORTSVG)
Vector export of the 2D drafting view. Tessellated WireModel sub-strokes -> <polyline>s, coloured per wire, fit to a viewBox, Y mirrored (CAD Y-up -> SVG Y-down), WYSIWYG page background. Command wiring mirrors STLOUT.
### 3. Persistence -- EXTRUDE / REVOLVE / SWEEP / LOFT / IMPORTOBJ
These stored their solid under a placeholder empty Solid3D, so it vanished on save/reload. The tessellation is now persisted as an ACAD_MESH entity (round-trips through both DWG and DXF) and re-tessellated to a shaded mesh on load (new scene::mesh_tess). Also removes the dead CommitSolid3D path (primitives already persist via real ACIS).
### 4. Performance, CI & tests
- Lazy raster-image decode (roadmap 1.6): decode deferred to first GPU upload via Arc<OnceLock>; off-screen images never decode.
- Profiling spans (roadmap 5.1): puffin behind a --features profile flag (zero cost otherwise).
- CI: build + test + clippy on every push/PR (was release-only); fmt non-blocking to respect the manual formatting.
- Tests 38 -> 101 on previously-untested code: offset/fillet/trim helpers, the LFF text engine, and the dimension formatters.
- Roadmap notes corrected (1.6 / 5.1 done; 3.5 and primitive-persistence already satisfied).
## How has this been tested?
- \`cargo build --all-targets\`, \`cargo test\` (101 pass), \`cargo clippy\`, and \`cargo check --features profile\` all green.
- Persistence: an integration test saves an ACAD_MESH entity and reads it back through the real acadrust writers/readers for both DWG and DXF.
- SVG export: unit tests plus an end-to-end headless-Chromium render of a sample drawing (correct geometry, orientation, colours).
- Bug fixes: regression tests assert linear width-factor scaling (and parity with the layout path) and each dimension rounding carry.
## Checklist
- [x] Builds without warnings on stable Rust
- [x] cargo test passes (38 -> 101)
- [x] cargo clippy clean on the changed code
- [x] MSRV preserved (Rust 1.75+)
- [x] README updated (SVG export added to the format list)
- [ ] Interactive GUI smoke-test by a maintainer with a display