### PR TITLE
fix(hatch): render baked patterns with many line families (#313)

### DIFF
--- a/src/scene/convert/tessellate.rs
+++ b/src/scene/convert/tessellate.rs
@@ -126,7 +126,16 @@ pub fn tessellate(
     // dominant wire-instance cost on hatch-heavy drawings (issue #131). Picking
     // is unaffected: hatches are caught by their fill area through the existing
     // `pick::hit_test::click_hit_hatch` path, not this outline.
-    if matches!(entity, EntityType::Hatch(_)) {
+    //
+    // A pattern with more line families than the GPU shader holds renders
+    // truncated as a fill, so rasterise it to line wires on the CPU instead
+    // (the GPU fill is skipped for these in `upload_hatches`). (#313)
+    if let EntityType::Hatch(dxf) = entity {
+        if let Some(model) = crate::scene::Scene::hatch_model_from_dxf(dxf, entity_color) {
+            if model.needs_wire_offload() {
+                return hatch_offload_wires(&model, handle, color);
+            }
+        }
         return vec![];
     }
 
@@ -949,6 +958,27 @@ pub(crate) enum ArrowKind {
     Origin { size: f32 },
     Box_ { size: f32, filled: bool },
     Datum { size: f32, filled: bool },
+}
+
+/// Rasterise a many-family hatch pattern to line-segment wires (issue #313).
+/// `pattern_segments` already returns segments in the offset-relative WCS, so
+/// pack them into one WireModel with NaN sentinels between disjoint segments.
+fn hatch_offload_wires(
+    model: &crate::scene::model::hatch_model::HatchModel,
+    handle: Handle,
+    color: [f32; 4],
+) -> Vec<WireModel> {
+    let segs = model.pattern_segments();
+    if segs.is_empty() {
+        return vec![];
+    }
+    let mut pts: Vec<[f64; 3]> = Vec::with_capacity(segs.len() * 3);
+    for seg in &segs {
+        pts.push([seg[0][0] as f64, seg[0][1] as f64, 0.0]);
+        pts.push([seg[1][0] as f64, seg[1][1] as f64, 0.0]);
+        pts.push([f64::NAN, f64::NAN, f64::NAN]);
+    }
+    vec![WireModel::solid_f64(handle.value().to_string(), pts, color, false)]
 }
 
 pub(crate) fn arrow_from_block(

--- a/src/scene/model/hatch_model.rs
+++ b/src/scene/model/hatch_model.rs
@@ -85,6 +85,15 @@ pub struct HatchModel {
 }
 
 impl HatchModel {
+    /// True when the pattern has more line families than the GPU shader holds.
+    pub fn needs_wire_offload(&self) -> bool {
+        matches!(
+            &self.pattern,
+            HatchPattern::Pattern(f)
+                if f.len() > crate::scene::pipeline::hatch_gpu::MAX_FAMILIES
+        )
+    }
+
     /// CPU-side rasteriser for `HatchPattern::Pattern` — produces the line
     /// segments inside the boundary so non-GPU consumers (PDF export,
     /// `paper_canvas`, print preview) can draw the actual pattern instead

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -1585,8 +1585,13 @@ impl Pipeline {
             self.gpu_hatch_batched = None;
             return;
         };
-        let renderable: Vec<HatchModel> =
-            hatches.iter().filter(|h| h.boundary.len() >= 3).cloned().collect();
+        // Skip hatches offloaded to CPU line-wire rendering (too many families
+        // for the GPU family shader) — their pattern is drawn as wires. (#313)
+        let renderable: Vec<HatchModel> = hatches
+            .iter()
+            .filter(|h| h.boundary.len() >= 3 && !h.needs_wire_offload())
+            .cloned()
+            .collect();
         self.gpu_hatch_batched =
             hatch_batched_gpu::HatchBatchedGpu::build(device, bgl1, &renderable);
     }


### PR DESCRIPTION
Fixes #313.

## Problem
Hatch fills are rasterised on the GPU by a per-fragment shader that holds at most `MAX_FAMILIES` (16) pattern line families. Other CAD software bakes complex patterns (`ROOFING`, `GRAVEL`, stone) into dozens–hundreds of one-off line families, so their fill rendered truncated — the roof shingle pattern in the sample showed only its horizontal courses, with every vertical joint missing (see the issue's OCS-vs-ODA comparison).

## Fix
Route hatches whose pattern exceeds the shader's family limit through the existing CPU rasteriser (`HatchModel::pattern_segments`, already used for PDF export and paper space) and draw the result as line-segment wires, which have no family cap. Simple patterns keep the fast GPU path; the GPU fill is skipped for the offloaded ones so nothing is drawn twice.

## Changes
- `HatchModel::needs_wire_offload()` — pattern has more families than the shader holds.
- `tessellate` — such hatches emit their pattern as wire segments instead of `vec![]`.
- `upload_hatches` — skips the GPU fill for offloaded hatches.
