### PR TITLE
Reduce binary size by strip=true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,6 @@ web-sys = { version = "0.3", features = [
 # system fonts, so without it all iced text (ribbon labels, command line) is
 # blank. Features merge with the main `iced` dependency.
 iced = { version = "0.14", features = ["webgl", "fira-sans"] }
+
+[profile.release]
+strip = true


### PR DESCRIPTION
Current binary size was 55MB. After `strip=true` binary size is reduced to 44MB. 