### PR TITLE
fix(plot): never fail silently on PDF export; add EXPORTPDF <path> (#369)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -303,8 +303,8 @@ Status of every standard CAD command in Open CAD Studio:
 | `QSAVE` | — | Quick save | ✅ |
 | `SAVEALL` | — | Save all open drawings | ✅ |
 | `PLOT` | — | Print / plot | ✅ |
-| `EXPORT` | — | Export | ✅ |
-| `EXPORTPDF` | — | Export to PDF | ✅ |
+| `EXPORT [path]` | — | Export to PDF (save dialog, or straight to `path`) | ✅ |
+| `EXPORTPDF [path]` | — | Export to PDF (save dialog, or straight to `path`) | ✅ |
 | `PAGESETUP` | — | Page setup | ✅ |
 | `PLOTSTYLE` | — | Plot style | ✅ |
 | `PURGE` | PU | Purge unused items | ✅ |

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -542,6 +542,56 @@ mod tests {
     }
 
     #[test]
+    fn exportpdf_with_explicit_path_writes_pdf_without_dialog() {
+        // EXPORTPDF <path> must export straight to the given file — no save
+        // dialog — and confirm on the command line. This is the dialog-free
+        // export path added for #369 (Export to PDF silently did nothing when
+        // the native save dialog could not open).
+        let mut app = OpenCADStudio::new_for_test();
+        app.automation_op(r#"{"op":"new"}"#);
+        app.automation_op(r#"{"op":"run","cmd":"LINE 0,0 100,50"}"#);
+
+        let path = std::env::temp_dir().join(format!("ocs_test_369_{}.pdf", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let start = app.command_line.history.len();
+        let _ = app.run_command_line(&format!("EXPORTPDF {}", path.display()));
+        let out: String = app.command_line.history[start..]
+            .iter()
+            .map(|e| e.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(out.contains("Exported"), "no export confirmation: {out:?}");
+
+        let bytes = std::fs::read(&path).expect("EXPORTPDF <path> should write the file");
+        assert!(bytes.starts_with(b"%PDF"), "output is not a PDF");
+        assert!(bytes.len() > 200, "suspiciously small PDF: {}", bytes.len());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn cancelled_pdf_save_dialog_reports_on_command_line() {
+        // The save dialog resolving to None (cancelled, or it never opened —
+        // e.g. a broken XDG portal) must leave a visible message, not silence.
+        // Regression for #369.
+        use crate::app::Message;
+        let mut app = OpenCADStudio::new_for_test();
+        app.automation_op(r#"{"op":"new"}"#);
+        for msg in [Message::PlotExportPath(None), Message::PlotWindowExportPath(None)] {
+            let start = app.command_line.history.len();
+            let _ = app.update(msg);
+            let out: String = app.command_line.history[start..]
+                .iter()
+                .map(|e| e.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                out.contains("EXPORTPDF"),
+                "dialog-None must mention the EXPORTPDF fallback: {out:?}"
+            );
+        }
+    }
+
+    #[test]
     fn save_then_open_round_trips() {
         let mut app = OpenCADStudio::new_for_test();
         let path = std::env::temp_dir().join("ocs_automation_test.dxf");

--- a/src/app/commands/display.rs
+++ b/src/app/commands/display.rs
@@ -365,8 +365,40 @@ impl OpenCADStudio {
             "PLOT" | "PRINT" => {
                 return Some(Task::done(Message::PlotDialogOpen));
             }
-            "EXPORT" | "EXPORTPDF" => {
-                return Some(Task::done(Message::PlotExport));
+            // With no argument these open the save dialog; with a path they
+            // export straight to it. The direct form is also the workaround for
+            // systems where the native save dialog cannot open at all (broken
+            // XDG portal / missing zenity on Linux) — there the dialog future
+            // resolves to None and no export would happen. (#369)
+            cmd if cmd == "EXPORT"
+                || cmd == "EXPORTPDF"
+                || cmd.starts_with("EXPORT ")
+                || cmd.starts_with("EXPORTPDF ") =>
+            {
+                // Strip the keyword actually typed — EXPORTPDF first, since
+                // EXPORT is its prefix (see #295 for the failure mode).
+                let arg = cmd
+                    .strip_prefix("EXPORTPDF")
+                    .or_else(|| cmd.strip_prefix("EXPORT"))
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"');
+                if arg.is_empty() {
+                    return Some(Task::done(Message::PlotExport));
+                }
+                let mut path = std::path::PathBuf::from(arg);
+                if path.extension().is_none() {
+                    path.set_extension("pdf");
+                }
+                // A bare filename lands next to the drawing when it has a home.
+                if path.is_relative() {
+                    if let Some(dir) =
+                        self.tabs[i].current_path.as_deref().and_then(|p| p.parent())
+                    {
+                        path = dir.join(path);
+                    }
+                }
+                return Some(self.on_plot_export_path_some(path));
             }
             // PLOTSTYLE — load or clear CTB/STB plot style table
             cmd if cmd == "PLOTSTYLE" || cmd.starts_with("PLOTSTYLE ") => {

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -1119,7 +1119,10 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 }
     }
 
-    pub(super) fn on_plot_export_path_some(&mut self, path: std::path::PathBuf) -> Task<Message> {
+    pub(in crate::app) fn on_plot_export_path_some(
+        &mut self,
+        path: std::path::PathBuf,
+    ) -> Task<Message> {
                 let i = self.active_tab;
                 let scene = &self.tabs[i].scene;
                 let wires = scene.entity_wires();
@@ -1222,10 +1225,12 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                     &path,
                     self.active_plot_style.as_ref(),
                 ) {
-                    Ok(()) => self.command_line.push_info(&format!(
-                        "Exported: {}",
-                        path.file_name().unwrap_or_default().to_string_lossy()
-                    )),
+                    // Full path, not just the file name — when the export was
+                    // driven by EXPORTPDF <path> the user needs to see where
+                    // the file actually landed. (#369)
+                    Ok(()) => self
+                        .command_line
+                        .push_info(&format!("Exported: {}", path.display())),
                     Err(e) => self.command_line.push_error(&format!("Export failed: {e}")),
                 }
                 Task::none()

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -3535,7 +3535,18 @@ impl OpenCADStudio {
                     Message::PlotExportPath,
                 )
             }
-            Message::PlotExportPath(None) => Task::none(),
+            // None means the save dialog was cancelled — or never opened at
+            // all (a broken XDG portal / missing zenity on Linux resolves to
+            // None too, and rfd only reports that through `log`, which is
+            // opt-in). Either way say something instead of silently doing
+            // nothing. (#369)
+            Message::PlotExportPath(None) => {
+                self.command_line.push_info(
+                    "PDF export canceled — no file chosen. \
+                     If no dialog appeared, use EXPORTPDF <path>.",
+                );
+                Task::none()
+            }
             Message::PlotExportPath(Some(path)) => self.on_plot_export_path_some(path),
 
             Message::PlotFormat(f) => {
@@ -3559,7 +3570,14 @@ impl OpenCADStudio {
                     Message::PlotWindowExportPath,
                 )
             }
-            Message::PlotWindowExportPath(None) => Task::none(),
+            // Same silent-None trap as PlotExportPath above. (#369)
+            Message::PlotWindowExportPath(None) => {
+                self.command_line.push_info(
+                    "PDF export canceled — no file chosen. \
+                     If no dialog appeared, use EXPORTPDF <path>.",
+                );
+                Task::none()
+            }
             Message::PlotWindowExportPath(Some(path)) => self.on_plot_window_export_path_some(path),
 
             // ── Print to system printer ───────────────────────────────────────


### PR DESCRIPTION
## Problem (#369)

"Export to PDF seems to be doing nothing (no errors and no action). No additional output in the console."

Every code path in the export flow pushes a visible command-line message — except one. The flow hands off to an async `rfd` save dialog, and when that future resolves to `None` the app mapped it straight to `Task::none()`:

```rust
Message::PlotExportPath(None) => Task::none(),
```

`None` doesn't only mean the user cancelled. On Linux, rfd 0.17's XDG portal `SaveFile` call can fail outright (portal missing/broken under some desktops); rfd then falls back to zenity, and when that isn't installed either, the future still just resolves to `None` (see PolyMeilex/rfd#315 for what that failure mode looks like). rfd reports all of this only through the `log` crate — and OCS initializes `env_logger` only when `--log`/`RUST_LOG` is set — so the user sees exactly what the issue describes: no dialog, no error, no console output, no file. (The reporter runs a native Linux build from source, per their earlier issues.)

## Fix

- **`EXPORT` / `EXPORTPDF` now take an optional path** — `EXPORTPDF out.pdf` exports straight to the file with no dialog. This is both the workaround for systems where the native save dialog cannot open, and a headless-testable entry point. Relative paths land next to the drawing; a missing extension gets `.pdf`. (Same command-argument pattern as `CUIEXPORT <path>`.)
- **The dialog-`None` arms (`PlotExportPath` / `PlotWindowExportPath`) now push a command-line message** pointing at `EXPORTPDF <path>` instead of doing nothing, so the failure is never invisible again.
- The success message prints the full output path instead of just the file name.
- `COMMANDS.md` updated for the `[path]` argument.

@ceremcem — could you retry on this branch? If the save dialog still doesn't appear on your system, `EXPORTPDF <path>` should export regardless, and running with `--log warn` will show rfd's portal/zenity errors so we can see exactly why the dialog fails there.

## Verification

- New test `exportpdf_with_explicit_path_writes_pdf_without_dialog` drives `EXPORTPDF <path>` through the real dispatcher and asserts a valid `%PDF` file plus the confirmation message; `cancelled_pdf_save_dialog_reports_on_command_line` asserts the dialog-`None` feedback. **Both fail on the previous code** (silent no-op / unknown command).
- Full suite green: `cargo test --lib` — 196 passed.
- End-to-end on the real binary (`--serve`): `LINE` + `CIRCLE` then `EXPORTPDF <path>` writes a valid PDF with the expected geometry (visually checked).

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
