### PR TITLE
fix(test): pass anno_scale arg to expand_insert in text_font_rendering

### DIFF
--- a/tests/text_font_rendering.rs
+++ b/tests/text_font_rendering.rs
@@ -72,6 +72,9 @@ fn expand_block_mtext(
         None,
         false,
         [0.0, 0.0, 0.0, 1.0],
+        // Annotation scale: 1.0 = no annotative scaling, matching the
+        // `BlockCache::build(&doc, 1.0, ...)` call above.
+        1.0,
     )
     .expect("block defn is cached")
 }


### PR DESCRIPTION
## What

Pass the `anno_scale` argument to `expand_insert` in the `text_font_rendering`
integration test so it compiles against the current signature.

## Why

The annotative feature (`1b037a6`, *feat(annotative): scale text/dims/tables/blocks
at the annotation scale…*) added a 15th parameter `anno_scale: f32` to
`scene::cache::block_cache::expand_insert` and updated the production call sites,
but `tests/text_font_rendering.rs` was left calling it with 14 arguments. The
test binary therefore fails to compile the moment it is rebuilt:

```
error[E0061]: this function takes 15 arguments but 14 arguments were supplied
  --> tests/text_font_rendering.rs:53
```

A plain `cargo build` misses this because the test isn't part of the default
build graph; `cargo test` (or CI) surfaces it.

## Change

One call site, `1.0` for `anno_scale` — i.e. no annotative scaling — matching the
`BlockCache::build(&doc, 1.0, ...)` the test already uses. No production code
touched.

## Verification

```
cargo test --test text_font_rendering
...
running 3 tests
test block_nested_mtext_fill_tris_keep_paired_low_half_at_utm ... ok
test block_nested_colour_split_mtext_keeps_per_wire_colour ... ok
test block_nested_mtext_uses_its_style_font ... ok

test result: ok. 3 passed; 0 failed; 0 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
