### PR TITLE
Fix LTSCALE refresh and circle linetype rendering

### DIFF
--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -1887,6 +1887,8 @@ impl OpenCADStudio {
                     if v > 0.0 {
                         self.push_undo_snapshot(i, "LTSCALE");
                         self.tabs[i].scene.document.header.linetype_scale = v;
+                        // LTSCALE affects the cached linetype geometry of the whole drawing.
+                        self.tabs[i].scene.bump_geometry();
                         self.tabs[i].dirty = true;
                         self.command_line
                             .push_output(crate::tf!("LTSCALE set to {v:.4}").as_ref());

--- a/src/scene/convert/tessellate.rs
+++ b/src/scene/convert/tessellate.rs
@@ -1189,7 +1189,14 @@ pub fn tessellate(
                 } else {
                     color
                 };
-
+                // Circles use the Lines path for large-coordinate precision, but they
+                // must still preserve the entity's resolved linetype pattern.
+                let (edge_pattern_length, edge_pattern) =
+                    if matches!(entity, EntityType::Circle(_)) {
+                        (pattern_length, pattern)
+                    } else {
+                        (0.0, [0.0; 8])
+                    };
                 if !local_pts.is_empty() {
                     let (snap, keys, tangents) = if is_first {
                         is_first = false;
@@ -1217,8 +1224,8 @@ pub fn tessellate(
                         points_low: local_pts_low,
                         color: edge_color,
                         selected,
-                        pattern_length: 0.0,
-                        pattern: [0.0; 8],
+                        pattern_length: edge_pattern_length,
+                        pattern: edge_pattern,
                         line_weight_px,
                         snap_pts: snap,
                         tangent_geoms: tangents,


### PR DESCRIPTION
## Summary

This PR fixes two related linetype rendering issues:

- Global `LTSCALE` changes now immediately refresh existing drawing geometry.
- Circle entities now preserve and display their assigned linetype patterns.

## Problem

Changing `LTSCALE` correctly updated the document header, but existing entities continued displaying their cached wire geometry. The new scale only became visible after individually modifying an entity.

Circle entities also ignored non-continuous linetypes because the `TruckObject::Lines` tessellation path created their wire geometry without preserving the resolved linetype pattern.

## Changes

- Invalidate cached drawing geometry after changing global `LTSCALE`.
- Preserve `pattern_length` and `pattern` when tessellating circle entities.
- Keep the existing continuous behavior for other entities using the `TruckObject::Lines` path.

## Testing

Manually tested with:

- Lines
- Polylines
- Arcs
- Circles
- Continuous, dashed and dash-dot linetypes
- Multiple global `LTSCALE` values
- Existing entities created before changing `LTSCALE`

All existing entities now refresh immediately after changing `LTSCALE`, and circles correctly display their assigned linetype.

Fixes #667