### PR TITLE
Fix text rotation transforms

### DIFF
--- a/src/entities/mtext.rs
+++ b/src/entities/mtext.rs
@@ -554,6 +554,11 @@ fn apply_transform(t: &mut MText, tr: &EntityTransform) {
         let line_angle = dy.atan2(dx);
         entity.rotation = 2.0 * line_angle - entity.rotation;
     });
+    // Keep MTEXT's explicit rotation in sync with ROTATE / ALIGN.
+    if let EntityTransform::Rotate { angle_rad, .. } = tr {
+        t.rotation =
+            (t.rotation + *angle_rad).rem_euclid(std::f64::consts::TAU);
+    }
 }
 
 impl TruckConvertible for MText {

--- a/src/entities/text.rs
+++ b/src/entities/text.rs
@@ -484,6 +484,12 @@ fn apply_transform(t: &mut Text, tr: &EntityTransform) {
         entity.rotation = 2.0 * line_angle - entity.rotation;
         entity.oblique_angle = -entity.oblique_angle;
     });
+    // The generic entity transform moves the TEXT geometry, but acadrust
+    // does not update the DXF rotation field used by our text renderer.
+    if let EntityTransform::Rotate { angle_rad, .. } = tr {
+        t.rotation =
+            (t.rotation + *angle_rad).rem_euclid(std::f64::consts::TAU);
+    }
 }
 
 impl TruckConvertible for Text {


### PR DESCRIPTION
## Summary

Fixes text rotation when applying geometric transforms.

Previously, `ROTATE` correctly transformed the position of TEXT and MTEXT entities, but their explicit rotation value was not updated, causing the rendered text to remain horizontal.

The same issue also affected `ALIGN`, since it uses the same transform path.

## Changes

- Update TEXT rotation when applying `EntityTransform::Rotate`.
- Update MTEXT rotation when applying `EntityTransform::Rotate`.
- Normalize the resulting rotation angle.

## Testing

Manually tested with:

- TEXT + ROTATE
- MTEXT + ROTATE
- Multiple successive rotations
- Positive and negative angles
- TEXT + ALIGN
- MTEXT + ALIGN

Text now rotates visually and its Rotation property remains synchronized with the applied transform.

Fixes #690