### PR TITLE
Fix linetype scaling for lines, arcs and ellipses

### DIFF
--- a/src/scene/convert/tessellate.rs
+++ b/src/scene/convert/tessellate.rs
@@ -1113,10 +1113,16 @@ pub fn tessellate(
                 } else {
                     color
                 };
-                // Circles use the Lines path for large-coordinate precision, but they
-                // must still preserve the entity's resolved linetype pattern.
+                // Basic curve entities use the Lines path for large-coordinate precision,
+                // but they must still preserve the entity's resolved linetype pattern.
                 let (edge_pattern_length, edge_pattern) =
-                    if matches!(entity, EntityType::Circle(_)) {
+                    if matches!(
+                        entity,
+                        EntityType::Line(_)
+                            | EntityType::Circle(_)
+                            | EntityType::Arc(_)
+                            | EntityType::Ellipse(_)
+                    ) {
                         (pattern_length, pattern)
                     } else {
                         (0.0, [0.0; 8])


### PR DESCRIPTION
## Summary

Fixes a regression where LINE, ARC and ELLIPSE entities lost their resolved linetype pattern when rendered through the `RenderObject::Lines` path.

CIRCLE already had a special case preserving `pattern_length` and `pattern`, while other basic curve entities were falling back to a solid line.

## Changes

- preserve the resolved linetype pattern for:
  - LINE
  - ARC
  - ELLIPSE
  - CIRCLE
- keep the existing fallback behavior for other `RenderObject::Lines` users

## Result

LTSCALE now affects LINE, ARC and ELLIPSE consistently with CIRCLE and POLYLINE.

## Validation

- `cargo check --bin OpenCADStudio -j3`
- `git diff --check`
- manually tested LINE
- manually tested ARC
- manually tested ELLIPSE
- manually verified CIRCLE still works
- manually verified POLYLINE still works