### PR TITLE
Fix CTB plotting for inherited block colors

### DIFF
--- a/src/scene/cache/block_cache.rs
+++ b/src/scene/cache/block_cache.rs
@@ -864,11 +864,13 @@ pub fn expand_insert(
     ins: &acadrust::entities::Insert,
     ins_handle: Handle,
     ins_resolved_color: [f32; 4],
+    ins_aci: u8,
     ins_pat_len: f32,
     ins_pat: [f32; 8],
     ins_lw_px: f32,
     // The INSERT's own layer style — layer-0 inheritance target for children.
     ins_layer: crate::scene::view::render::InheritStyle,
+    ins_layer_aci: u8,
     selected: bool,
     pslt_factor: f32,
     // World-space XY view AABB (with world_offset already subtracted, so the
@@ -1004,10 +1006,12 @@ pub fn expand_insert(
         let ctx = ExpandCtx {
             cache,
             ins_color: ins_resolved_color,
+            ins_aci,
             ins_pat_len,
             ins_pat,
             ins_lw_px,
             l0: ins_layer,
+            l0_aci: ins_layer_aci,
             selected,
             pslt_factor,
             view_aabb,
@@ -1157,12 +1161,14 @@ fn aabb_pixel_size(local_aabb: [f32; 4], world_per_pixel: f32) -> f32 {
 struct ExpandCtx<'a> {
     cache: &'a BlockCache,
     ins_color: [f32; 4],
+    ins_aci: u8,
     ins_pat_len: f32,
     ins_pat: [f32; 8],
     ins_lw_px: f32,
     /// Layer-0 inheritance target — the current INSERT's *layer* style, used
     /// for child wires on layer "0" whose properties are ByLayer.
     l0: crate::scene::view::render::InheritStyle,
+    l0_aci: u8,
     selected: bool,
     pslt_factor: f32,
     // World-space XY view AABB (post world_offset). `None` = no culling.
@@ -1494,19 +1500,21 @@ fn expand_defn(
                         ctx.ins_pat_len,
                         ctx.ins_pat,
                         ctx.ins_lw_px,
-                        0,
+                        ctx.ins_aci,
                     ),
                     layer0: ctx.l0,
-                    layer0_aci: 0,
+                    layer0_aci: ctx.l0_aci,
                 };
                 let nested_style = nref.style.resolve(parent_style);
                 let inner_ctx = ExpandCtx {
                     cache: ctx.cache,
                     ins_color: nested_style.insert.0,
+                    ins_aci: nested_style.insert.4,
                     ins_pat_len: nested_style.insert.1,
                     ins_pat: nested_style.insert.2,
                     ins_lw_px: nested_style.insert.3,
                     l0: nested_style.layer0,
+                    l0_aci: nested_style.layer0_aci,
                     selected: ctx.selected,
                     pslt_factor: ctx.pslt_factor,
                     view_aabb: ctx.view_aabb,
@@ -1664,6 +1672,13 @@ fn emit_wire(
     // Resolve final style for this LocalWire against the outer Insert ctx
     // before we hash it into a batch.
     let final_color = resolve_wire_color(lw, ctx);
+    let final_aci = if lw.color_is_byblock {
+            ctx.ins_aci
+        } else if lw.color_l0 {
+            ctx.l0_aci
+        } else {
+            lw.aci
+        };
     let (final_pat_len, final_pat) = if lw.lt_is_byblock {
         (ctx.ins_pat_len, ctx.ins_pat)
     } else if lw.lt_l0 {
@@ -1718,7 +1733,7 @@ fn emit_wire(
         final_pat,
         final_lw_px,
         final_world_width,
-        lw.aci,
+        final_aci,
         lw.plinegen,
         lw.is_fill_only,
         lw.fill_is_2d_solid,
@@ -1741,7 +1756,7 @@ fn emit_wire(
             final_pat,
             final_lw_px,
             final_world_width,
-            lw.aci,
+            final_aci,
             lw.plinegen,
             lw.is_fill_only,
             lw.fill_is_2d_solid,

--- a/src/scene/convert/tess.rs
+++ b/src/scene/convert/tess.rs
@@ -1038,7 +1038,7 @@ pub(crate) fn tessellate_entity(
 
     if let EntityType::Insert(ins) = e {
         // Resolve the INSERT's own style so ByBlock sub-entities can inherit it.
-        let (ins_color, ins_pat_len, ins_pat, ins_lw_px, _) =
+        let (ins_color, ins_pat_len, ins_pat, ins_lw_px, ins_aci) =
             view::render::render_style_for_viewport(document, e, active_viewport);
         let ins_color = view::render::adapt_to_bg(ins_color, bg_color);
         // Resolve the INSERT's *layer* style — the layer-0 inheritance target
@@ -1052,6 +1052,14 @@ pub(crate) fn tessellate_entity(
             s.color = view::render::adapt_to_bg(s.color, bg_color);
             s
         };
+        let ins_layer_aci = document
+            .layers
+            .get(&ins.common.layer)
+            .and_then(|layer| match &layer.color {
+                acadrust::types::Color::Index(index) => Some(*index),
+                _ => None,
+            })
+            .unwrap_or(0);
         let ip = glam::Vec3::new(
             (ins.insert_point.x) as f32,
             (ins.insert_point.y) as f32,
@@ -1114,10 +1122,12 @@ pub(crate) fn tessellate_entity(
             ins,
             h,
             ins_color,
+            ins_aci,
             ins_pat_len,
             ins_pat,
             ins_lw_px,
             ins_layer,
+            ins_layer_aci,
             sel,
             pslt_factor,
             view_aabb,


### PR DESCRIPTION
## Summary

Fixes CTB plot-style resolution for block contents using Layer 0 + ByLayer properties.

## Problem

Block geometry correctly inherited the visible properties from the INSERT layer, but the effective ACI used by CTB plotting was not propagated through block expansion.

This caused blocks inserted on colored layers to use the wrong CTB pen assignment.

## Fix

- Propagate the effective INSERT ACI through block expansion.
- Propagate the Layer 0 inheritance ACI.
- Preserve inherited ACI through nested blocks.
- Use the resolved ACI when creating final block wire batches.

## Testing

Tested the same Layer 0 / ByLayer block inserted on different colored layers with different CTB lineweights. Each instance now plots with the correct pen assignment.

`cargo check --bin OpenCADStudio -j3` passes.