### PR TITLE
Fix dimension styles incorrectly treated as read-only

### DIFF
--- a/src/app/style_ops.rs
+++ b/src/app/style_ops.rs
@@ -612,21 +612,7 @@ impl OpenCADStudio {
     }
 
     pub(super) fn style_delete(&mut self, kind: StyleKind) {
-        let name = self.style_selected(kind);
-        if matches!(kind, StyleKind::Dim)
-            && self.tabs[self.active_tab]
-                .scene
-                .document
-                .dim_styles
-                .get(&name)
-                .is_some_and(|style| {
-                    style.xref_reference || style.xref_dependent || !style.xref_handle.is_null()
-                })
-        {
-            self.command_line
-                .push_error(crate::t!("Referenced styles are read only.").as_ref());
-            return;
-        }
+        let name = self.style_selected(kind);        
         if name.eq_ignore_ascii_case("Standard") {
             self.command_line
                 .push_error(crate::t!("Cannot delete the Standard style.").as_ref());
@@ -671,20 +657,7 @@ impl OpenCADStudio {
         if new.is_empty() || new.eq_ignore_ascii_case(&old) {
             return;
         }
-        if matches!(kind, StyleKind::Dim)
-            && self.tabs[self.active_tab]
-                .scene
-                .document
-                .dim_styles
-                .get(&old)
-                .is_some_and(|style| {
-                    style.xref_reference || style.xref_dependent || !style.xref_handle.is_null()
-                })
-        {
-            self.command_line
-                .push_error(crate::t!("Referenced styles are read only.").as_ref());
-            return;
-        }
+
         if old.eq_ignore_ascii_case("Standard") {
             self.command_line
                 .push_error(crate::t!("Cannot rename the Standard style.").as_ref());

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -7243,21 +7243,9 @@ impl OpenCADStudio {
             Message::DimStyleDialogSetCurrent => {
                 // Staged: persists on Apply.
                 let i = self.active_tab;
-                let read_only = self.tabs[i]
-                    .scene
-                    .document
-                    .dim_styles
-                    .get(&self.dimstyle_selected)
-                    .is_some_and(|style| {
-                        style.xref_reference
-                            || style.xref_dependent
-                            || !style.xref_handle.is_null()
-                    });
-                if read_only {
-                    return Task::none();
-                }
+
                 self.tabs[i].scene.document.header.current_dimstyle_name =
-                    self.dimstyle_selected.clone();
+                    self.dimstyle_selected.clone(); 
                 self.sync_ribbon_styles();
                 self.command_line.push_output(crate::tf!(
                     "Current dim style set to '{}'.",

--- a/src/app/update/style.rs
+++ b/src/app/update/style.rs
@@ -358,15 +358,7 @@ impl OpenCADStudio {
 
     pub(in crate::app) fn apply_dimstyle_bufs(&mut self, tab: usize) {
         let doc = &mut self.tabs[tab].scene.document;
-        let read_only = doc
-            .dim_styles
-            .get(&self.dimstyle_selected)
-            .is_some_and(|style| {
-                style.xref_reference || style.xref_dependent || !style.xref_handle.is_null()
-            });
-        if read_only {
-            return;
-        }
+
         let text_style_handle = doc
             .text_styles
             .get(&self.ds_dimtxsty)
@@ -1185,11 +1177,6 @@ pub(super) fn on_text_style_dialog_open(&mut self) -> Task<Message> {
                     "dimltex_handle" | "dimltex1_handle" | "dimltex2_handle"
                 );
                 let doc = &self.tabs[i].scene.document;
-                if doc.dim_styles.get(&name).is_some_and(|style| {
-                    style.xref_reference || style.xref_dependent || !style.xref_handle.is_null()
-                }) {
-                    return Task::none();
-                }
                 let handle = if value == "Default" || value == "ByBlock" {
                     acadrust::types::Handle::NULL
                 } else if is_lt {

--- a/src/app/view/modal.rs
+++ b/src/app/view/modal.rs
@@ -1030,9 +1030,7 @@ impl OpenCADStudio {
                 }
             };
             let ds_sel = doc.dim_styles.get(&self.dimstyle_selected);
-            let read_only = ds_sel.is_some_and(|style| {
-                style.xref_reference || style.xref_dependent || !style.xref_handle.is_null()
-            });
+            let read_only = false;
             let in_use = doc.entities().any(|entity| {
                 matches!(entity, acadrust::EntityType::Dimension(dimension)
                     if dimension.base().style_name.eq_ignore_ascii_case(&self.dimstyle_selected))


### PR DESCRIPTION
## Summary

Fixes an issue where dimension styles loaded from DWG files were incorrectly treated as referenced/read-only styles.

This prevented existing dimension styles from being properly edited, applied, renamed, deleted, or set as current.

## Cause

The Dimension Style Manager was using XREF-related flags, including `xref_reference`, to determine whether a dimension style should be read-only.

For local dimension styles loaded from some DWG files, `xref_reference` can be set even though the style is not actually an external-reference-dependent style.

As a result, local styles such as `Standard` and user-created dimension styles were incorrectly classified as:

> Referenced style · Read only

Additional read-only checks in the dimension style update and style operations code also prevented changes from actually being applied even after the UI controls were enabled.

## Changes

- Allow all dimension styles to be edited in the Dimension Style Manager.
- Remove the incorrect XREF-based read-only checks from dimension style editing.
- Allow changes made in the Dimension Style Manager to be applied correctly.
- Allow dimension styles to be set as current.
- Allow custom dimension styles to be renamed and deleted according to the existing usage rules.
- Keep the `Standard` dimension style protected from deletion and renaming.
- Preserve the existing protection against deleting dimension styles that are currently in use.

## Testing

Tested with an existing DWG containing multiple dimension styles.

Verified that:

- `Standard` can be edited.
- Existing custom dimension styles can be edited.
- Dimension style property changes are correctly applied to the drawing.
- Arrow size changes are reflected in dimensions.
- Custom styles can be deleted when they are not in use.
- Styles currently in use remain protected from deletion.
- `Standard` cannot be deleted or renamed.
- Dimension styles can be set as current.

## Follow-up

The live preview inside the Dimension Style Manager could still be improved, but that is separate from this fix and should be handled in a follow-up change.