### PR TITLE
Improve plot style editing and Print All plot actions

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2755,7 +2755,9 @@ pub enum Message {
     PlotStylePanelScreenBuf(String),
     /// Apply current edit buffers to the selected ACI entry.
     PlotStylePanelApply,
-    /// Save the modified table back to disk.
+    /// Save the modified table directly over the currently edited CTB.
+    PlotStylePanelSaveDirect,
+    /// Save the modified table under a chosen name/path.
     PlotStylePanelSave,
     /// Save callback.
     PlotStylePanelSavePath(Option<std::path::PathBuf>),

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -3318,10 +3318,7 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 }
                 Task::none()
             }
-            M::SetCurrent => {
-                if self.print_all_options {
-                    return Task::none();
-                }
+            M::SetCurrent => { 
                 self.apply_dialog_to_layout();
                 self.command_line.push_info(crate::t!("Page setup applied to the layout.").as_ref());
                 Task::none()
@@ -3424,7 +3421,6 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 self.plot_dialog.name_rename = false;
                 Task::none()
             }
-            M::Preview if self.print_all_options => Task::none(),
             M::Preview => self.on_plot_dlg_commit(true),
             M::Commit if self.print_all_options => {
                 if self.plot_dialog.style_missing {

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -6531,6 +6531,32 @@ impl OpenCADStudio {
 
             // ── Plot Style Panel ──────────────────────────────────────────────
             Message::PlotStylePanelOpen => {
+                // The Plot dialog's selected table is authoritative. Make sure
+                // the editor opens that table rather than a stale active table.
+                let selected_style = self.plot_dialog.style_name.clone();
+
+                if selected_style.is_empty() {
+                    self.active_plot_style = None;
+                } else {
+                    let needs_load = self
+                        .active_plot_style
+                        .as_ref()
+                        .is_none_or(|table| !table.name.eq_ignore_ascii_case(&selected_style));
+
+                    if needs_load {
+                        match crate::io::plot_style::PlotStyleTable::load_named(&selected_style) {
+                            Ok(table) => {
+                                self.active_plot_style = Some(table);
+                                self.plot_dialog.style_missing = false;
+                            }
+                            Err(error) => {
+                                self.plot_dialog.style_missing = true;
+                                self.command_line.push_error(&error);
+                                return Task::none();
+                            }
+                        }
+                    }
+                }
                 // Initialise edit buffers for ACI 1.
                 self.plotstyle_panel_aci = 1;
                 let entry = self
@@ -6610,9 +6636,58 @@ impl OpenCADStudio {
 
             Message::PlotStylePanelApply => self.on_plot_style_panel_apply(),
 
-            Message::PlotStylePanelSave => self.on_plot_style_panel_save(),
+            Message::PlotStylePanelSaveDirect => {
+            let Some(table) = self.active_plot_style.as_ref() else {
+                self.command_line.push_error(
+                    crate::t!("No plot style table loaded. Load or create one first.").as_ref(),
+                );
+                return Task::none();
+            };
 
-            Message::PlotStylePanelSavePath(Some(path)) => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let table_name = table.name.clone();
+
+                let result = crate::io::plot_style::ensure_plot_styles_dir().and_then(|dir| {
+                    let path = dir.join(&table_name);
+                    table.save(&path)?;
+                    Ok(path)
+                });
+
+                match result {
+                    Ok(path) => {
+                        self.plot_dialog.style_name = table_name;
+                        self.plot_dialog.style_missing = false;
+                        self.plot_dialog.plot_styles =
+                            crate::io::plot_style::available_ctb_names();
+
+                        self.command_line.push_output(
+                            crate::tf!(
+                                "Plot style table saved to \"{}\".",
+                                path.display()
+                            )
+                            .as_ref(),
+                        );
+                    }
+                    Err(error) => {
+                        self.command_line
+                            .push_error(crate::tf!("Save error: {error}").as_ref());
+                    }
+                }
+
+                Task::none()
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                // Browsers cannot overwrite a local file directly, so fall back
+                // to the existing Save As flow.
+                self.on_plot_style_panel_save()
+            }
+        }
+
+        Message::PlotStylePanelSave => self.on_plot_style_panel_save(),
+        Message::PlotStylePanelSavePath(Some(path)) => {
                 let path = if path
                     .extension()
                     .is_some_and(|extension| extension.eq_ignore_ascii_case("ctb"))

--- a/src/ui/style/plotstyle.rs
+++ b/src/ui/style/plotstyle.rs
@@ -133,6 +133,10 @@ pub fn view_window<'a>(
                 .on_press(Message::PlotStyleLoad)
                 .style(btn_s(false))
                 .padding([4, 10]),
+            button(text(t!("Save")).size(11))
+                .on_press(Message::PlotStylePanelSaveDirect)
+                .style(btn_s(true))
+                .padding([4, 14]),
             button(text(t!("Save As…")).size(11))
                 .on_press(Message::PlotStylePanelSave)
                 .style(btn_s(false))

--- a/src/ui/window/plot.rs
+++ b/src/ui/window/plot.rs
@@ -892,24 +892,22 @@ pub fn view_window(
     let body = row![list_panel, vsep(height), detail]
         .width(width)
         .height(height);
-    let mut toolbar_row = row![left_bar, Space::new().width(width)].align_y(iced::Center);
-    if !print_all_options {
-        toolbar_row = toolbar_row
-            .push(
-                button(text(t!("Set current")).size(11))
-                    .on_press(Message::PlotDlg(PlotDlgMsg::SetCurrent))
-                    .style(btn(false))
-                    .padding([4, 12]),
-            )
-            .push(Space::new().width(6))
-            .push(
-                button(text(t!("Preview")).size(11))
-                    .on_press(Message::PlotDlg(PlotDlgMsg::Preview))
-                    .style(btn(false))
-                    .padding([4, 12]),
-            )
-            .push(Space::new().width(6));
-    }
+    let mut toolbar_row = row![left_bar, Space::new().width(width)]
+    .align_y(iced::Center)
+    .push(
+        button(text(t!("Set current")).size(11))
+            .on_press(Message::PlotDlg(PlotDlgMsg::SetCurrent))
+            .style(btn(false))
+            .padding([4, 12]),
+    )
+    .push(Space::new().width(6))
+    .push(
+        button(text(t!("Preview")).size(11))
+            .on_press(Message::PlotDlg(PlotDlgMsg::Preview))
+            .style(btn(false))
+            .padding([4, 12]),
+    )
+    .push(Space::new().width(6));
     toolbar_row = toolbar_row.push(
         button(text(action).size(11))
             .on_press(Message::PlotDlg(PlotDlgMsg::Commit))


### PR DESCRIPTION
## Summary

This PR fixes two related plotting/printing workflow issues:

1. The Plot Style editor could open and save against the wrong CTB table.
2. The Plot dialog opened from `Print All -> Options` was missing actions that are available when opening the Plot dialog normally.

## Changes

### Plot style editor
- Make the `Edit...` action open the plot style table currently selected in the Plot dialog.
- Add a highlighted `Save` button to the Plot Style editor toolbar.
- `Save` now writes directly back to the currently edited CTB table.
- Keep `Save As...` as the separate workflow for saving to another file.

### Print All -> Options
- Show `Set Current` in the Plot dialog when it is opened from `Print All -> Options`.
- Show `Preview` in the Plot dialog when it is opened from `Print All -> Options`.
- Enable both actions so they behave consistently with the normal Plot dialog entry path.
- Preserve the existing `Apply` action for the Print All options workflow.

## Problem details

### Plot style issue
The Plot dialog could display one selected CTB table while the Plot Style editor was still editing a stale `active_plot_style`, causing `Edit...` to open the wrong file (for example `ocad.ctb` instead of the table selected in the dialog).

In addition, users had no direct way to overwrite the currently edited CTB table from the editor itself, only `Save As...`.

### Print All issue
When the Plot dialog was opened through `Print All -> Options`, the UI hid `Set Current` and `Preview`, and their handlers were also disabled. This made the same dialog behave differently depending on how it was opened.

## Result

### Plot styles
- Selecting a CTB in the Plot dialog and pressing `Edit...` now opens that selected CTB.
- The new highlighted `Save` button overwrites the currently edited CTB.
- `Save As...` still works independently for creating/saving another file.

### Print All
Opening Plot from the command line still provides:
- `Set Current`
- `Preview`
- `Export PDF / Print`

Opening Plot from:
`Print All -> Options`

now provides:
- `Set Current`
- `Preview`
- `Apply`

with working handlers for those actions.

## Testing

Verified that:
- `Edit...` opens the CTB currently selected in the Plot dialog.
- Changes saved with the new `Save` button persist in the same CTB file.
- `Save As...` still saves to a different file as expected.
- Opening the Plot dialog normally still works correctly.
- Opening the Plot dialog from `Print All -> Options` now shows `Set Current` and `Preview`.
- `Set Current` and `Preview` both function from that entry path.