### PR TITLE
Fix current layer handling for HATCH and DWG files

### DIFF
--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -1203,7 +1203,8 @@ impl OpenCADStudio {
             CmdResult::CommitHatch(hatch) => {
                 let label = self.history_label_from_active_cmd(i, "HATCH");
                 let pending = self.begin_undo(i, label, 1, true);
-                let new_handle = self.tabs[i].scene.add_hatch(hatch);
+                let layer = self.tabs[i].active_layer.clone();
+                let new_handle = self.tabs[i].scene.add_hatch(hatch, Some(&layer));
                 if !new_handle.is_null() {
                     self.tabs[i].scene.select_entity(new_handle, true);
                 }
@@ -2914,6 +2915,12 @@ impl OpenCADStudio {
                 angle,
             } => {
                 if let Some(mut model) = self.tabs[i].scene.hatches.get(&handle).cloned() {
+                    let layer = self.tabs[i]
+                        .scene
+                        .document
+                        .get_entity(handle)
+                        .map(|entity| entity.as_entity().layer().to_string())
+                        .unwrap_or_else(|| "0".to_string());
                     // Update model fields
                     if !name.is_empty() {
                         use crate::scene::model::hatch_model::HatchPattern;
@@ -2933,7 +2940,7 @@ impl OpenCADStudio {
                     // Remove old hatch (entity + GPU model)
                     self.tabs[i].scene.erase_entities(&[handle]);
                     // Re-add with updated model
-                    self.tabs[i].scene.add_hatch(model);
+                    self.tabs[i].scene.add_hatch(model, Some(&layer));
                     self.tabs[i].dirty = true;
                     self.command_line.push_output(crate::t!("HATCHEDIT: hatch updated.").as_ref());
                 } else {

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -1096,6 +1096,34 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 self.tabs[i].scene.material_base_dir =
                     path.parent().map(std::path::Path::to_path_buf);
                 self.tabs[i].scene.document = doc;
+                // DWG stores CLAYER as a layer handle. Resolve that handle back to
+                // the layer name after opening so the per-tab creation state and
+                // header name stay in sync. DXF already provides current_layer_name,
+                // so keep it as a fallback.
+                let current_layer = {
+                    let doc = &self.tabs[i].scene.document;
+
+                    doc.layers
+                        .iter()
+                        .find(|layer| layer.handle == doc.header.current_layer_handle)
+                        .map(|layer| (layer.name.clone(), layer.handle))
+                        .or_else(|| {
+                            doc.layers
+                                .get(&doc.header.current_layer_name)
+                                .map(|layer| (layer.name.clone(), layer.handle))
+                        })
+                        .or_else(|| {
+                            doc.layers
+                                .get("0")
+                                .map(|layer| (layer.name.clone(), layer.handle))
+                        })
+                };
+
+                if let Some((name, handle)) = current_layer {
+                    self.tabs[i].scene.document.header.current_layer_name = name.clone();
+                    self.tabs[i].scene.document.header.current_layer_handle = handle;
+                    self.tabs[i].active_layer = name;
+                }
                 // A file saved without the built-in Standard styles (foreign
                 // or damaged) gets them re-seeded so nothing dangles (#366).
                 crate::app::style_ops::ensure_standard_styles(

--- a/src/scene/entity.rs
+++ b/src/scene/entity.rs
@@ -2000,7 +2000,7 @@ impl Scene {
         }
     }
 
-    pub fn add_hatch(&mut self, model: HatchModel) -> Handle {
+    pub fn add_hatch(&mut self, model: HatchModel, layer: Option<&str>) -> Handle {
         let mut dxf = DxfHatch::new();
         dxf.is_solid = matches!(
             model.pattern,
@@ -2117,14 +2117,19 @@ impl Scene {
                 },
             ];
         }
-
         // `add_entity` already builds the render model from the DXF entity via
         // `hatch_model_from_dxf` and inserts it with a correct `world_origin`
         // (AABB-centred) for the relative-to-eye fill. The command-built `model`
         // carries `world_origin: [0, 0]`, which after the world_offset removal
         // leaves the fill mis-placed and effectively invisible until a later
         // edit rebuilds it from the DXF — so keep the seed, don't overwrite it.
-        self.add_entity(EntityType::Hatch(dxf))
+        let mut entity = EntityType::Hatch(dxf);
+
+        if let Some(layer) = layer {
+            entity.as_entity_mut().set_layer(layer.to_string());
+        }
+
+        self.add_entity(entity)
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
## Summary

This PR addresses the current-layer issues reported in #742 and #743.

### #742 — HATCH is not created on the current layer

New HATCH entities were bypassing the normal entity creation path that applies the active layer.

The HATCH creation path now explicitly passes the current layer when creating the entity.

HATCHEDIT also preserves the hatch's existing layer instead of moving an edited hatch to the currently active layer.

Tested with `Layer1` active: newly created hatches are now correctly assigned to `Layer1`.

Fixes #742.

### #743 — Current layer is not restored after reopening a DWG

On the OpenCADStudio side, the DWG `CLAYER` handle is now resolved back to its layer name after loading and synchronized with the tab's `active_layer`.

During debugging I found that there is also an issue in the currently pinned `cadcodec/acadrust` revision (`74c5fe9`) which prevents #743 from being fully resolved by OpenCADStudio alone.

@HakanSeven12, the remaining issue appears to be in:

`src/io/dwg/dwg_stream_readers/merged_reader.rs`

inside `setup_text_and_handle()`.

The current R2007+ handle-stream calculation is:

```rust
let handle_start = ((total_size_bits + 1 + 7) / 8) * 8;
```

However, `total_size_bits` already includes the text-present flag bit. The additional `+ 1` can advance the handle reader by one byte when the boundary is already byte-aligned.

Changing it locally to:

```rust
let handle_start = ((total_size_bits + 7) / 8) * 8;
```

resolved the issue during testing.

Before patching cadcodec, OpenCADStudio correctly saved:

```text
current layer: Layer1
handle: Handle(98)
```

but after reopening the DWG, the currently pinned cadcodec revision returned:

```text
Handle(1)
```

which did not resolve to any loaded layer.

With the one-line cadcodec change above, the DWG reopened with the correct `CLAYER` handle and the OpenCADStudio-side logic in this PR restored `Layer1` as the current layer.

Therefore, the OpenCADStudio side of #743 is included in this PR, but #743 will only be fully resolved once the cadcodec fix is applied and OpenCADStudio updates its pinned cadcodec revision.

Addresses #743.

## Testing

- Created a HATCH with `Layer1` active → hatch is created on `Layer1`.
- HATCHEDIT preserves the hatch's existing layer.
- Saved a DWG with `Layer1` as the current layer.
- With the local cadcodec fix described above, reopened the DWG → `Layer1` is restored as the current layer.
- `cargo check --release --bin OpenCADStudio` passes with only the existing dead-code warnings.
